### PR TITLE
Jei užpildyta, naudoti "name:lt" žymą, o ne "name"

### DIFF
--- a/osm2pgsql.style
+++ b/osm2pgsql.style
@@ -108,6 +108,7 @@ node,way   man_made     text         polygon
 node,way   military     text         polygon
 node,way   motorcar     text         linear
 node,way   name         text         linear
+node,way   name:lt      text         linear
 node,way   natural      text         polygon  # natural=coastline tags are discarded by a hard coded rule in osm2pgsql
 node,way   office       text         polygon
 node,way   oneway       text         linear

--- a/queries/places/z11.pgsql
+++ b/queries/places/z11.pgsql
@@ -1,6 +1,6 @@
 SELECT
   way AS __geometry__,
-  name,
+  coalesce("name:lt", name) AS name,
   CASE
     WHEN place='town' and rank='0'
       THEN 'town'
@@ -21,7 +21,7 @@ WHERE
 
 SELECT
   ST_PointOnSurface(way) AS __geometry__,
-  name,
+  coalesce("name:lt", name) AS name,
   'water' AS kind,
   null AS population
 FROM

--- a/queries/places/z14.pgsql
+++ b/queries/places/z14.pgsql
@@ -1,6 +1,6 @@
 SELECT
   way AS __geometry__,
-  name,
+  coalesce("name:lt", name) AS name,
   CASE
     WHEN place='town' and rank='0'
       THEN 'town'
@@ -21,7 +21,7 @@ UNION ALL
 
 SELECT
   ST_PointOnSurface(way) AS __geometry__,
-  name,
+  coalesce("name:lt", name) AS name,
   'water' AS kind,
   null AS population
 FROM

--- a/queries/places/z8.pgsql
+++ b/queries/places/z8.pgsql
@@ -1,6 +1,6 @@
 SELECT
   way AS __geometry__,
-  name,
+  coalesce("name:lt", name) AS name,
   CASE
     WHEN place='town' and rank='0'
       THEN 'town'

--- a/queries/places/z9.pgsql
+++ b/queries/places/z9.pgsql
@@ -1,6 +1,6 @@
 SELECT
   way AS __geometry__,
-  name,
+  coalesce("name:lt", name) AS name,
   CASE
     WHEN place='town' and rank='0'
       THEN 'town'

--- a/queries/water/z11.pgsql
+++ b/queries/water/z11.pgsql
@@ -12,7 +12,7 @@ SELECT
       THEN 'stream'
     END
   ) AS kind,
-  name
+  coalesce("name:lt", name) AS name
 FROM
   planet_osm_line
 WHERE
@@ -40,7 +40,7 @@ SELECT
         THEN 'swimming_pool'
     END
   ) AS kind,
-  name
+  coalesce("name:lt", name) AS name
 FROM
   planet_osm_polygon
 WHERE

--- a/queries/water/z16.pgsql
+++ b/queries/water/z16.pgsql
@@ -16,7 +16,7 @@ SELECT
       THEN 'drain'
     END
   ) AS kind,
-  name
+  coalesce("name:lt", name) AS name
 FROM
   planet_osm_line
 WHERE
@@ -44,7 +44,7 @@ SELECT
         THEN 'swimming_pool'
     END
   ) AS kind,
-  name
+  coalesce("name:lt", name) AS name
 FROM
   planet_osm_polygon
 WHERE

--- a/queries/water/z9.pgsql
+++ b/queries/water/z9.pgsql
@@ -10,7 +10,7 @@ SELECT
       THEN 'river'
     END
   ) AS kind,
-  name
+  coalesce("name:lt", name) AS name
 FROM
   planet_osm_line
 WHERE
@@ -38,7 +38,7 @@ SELECT
         THEN 'swimming_pool'
     END
   ) AS kind,
-  name
+  coalesce("name:lt", name) AS name
 FROM
   planet_osm_polygon
 WHERE


### PR DESCRIPTION
Pasienio regione ir už Lietuvos ribų, name žymose gali būti užsienietiški arba kombinuoti pavadinimai „Lietuviškas / Užsienietiškas“, tai stengtis naudoti "name:lt" žymą su tik lietuvišku pavadinimu, jei toks yra įvestas.