### PR TITLE
Stiliaus pagražinimai. Daugiau vandens. Pasiruošimas 3d pastatams.

### DIFF
--- a/demo/styles/map.json
+++ b/demo/styles/map.json
@@ -65,6 +65,39 @@
       }
     },
     {
+      "id": "landuse-forest",
+      "type": "fill",
+      "source": "tilezen",
+      "source-layer": "landuse",
+      "minzoom": 7,
+      "filter": [
+        "all",
+        [
+          "in",
+          "kind",
+          "forest"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": {
+          "stops": [
+            [
+              6,
+              "rgba(255, 255, 255, 1)"
+            ],
+            [
+              12,
+              "rgba(136, 220, 122, 1)"
+            ]
+          ]
+        },
+        "fill-opacity": 1
+      }
+    },
+    {
       "id": "water-polygon",
       "type": "fill",
       "source": "tilezen",
@@ -75,7 +108,8 @@
         "Polygon"
       ],
       "paint": {
-        "fill-color": "#7acad0"
+        "fill-color": "#7acad0",
+        "fill-outline-color": "rgba(149, 154, 212, 0.6)"
       }
     },
     {
@@ -151,39 +185,6 @@
       ],
       "paint": {
         "fill-color": "rgba(196, 243, 189, 1)",
-        "fill-opacity": 1
-      }
-    },
-    {
-      "id": "landuse-forest",
-      "type": "fill",
-      "source": "tilezen",
-      "source-layer": "landuse",
-      "minzoom": 7,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "forest"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
-      "paint": {
-        "fill-color": {
-          "stops": [
-            [
-              6,
-              "rgba(255, 255, 255, 1)"
-            ],
-            [
-              12,
-              "rgba(136, 220, 122, 1)"
-            ]
-          ]
-        },
         "fill-opacity": 1
       }
     },
@@ -399,7 +400,7 @@
       "type": "fill",
       "source": "tilezen",
       "source-layer": "buildings",
-      "minzoom": 14,
+      "minzoom": 15,
       "maxzoom": 20,
       "paint": {
         "fill-outline-color": {
@@ -423,6 +424,32 @@
             [
               20,
               "#888888"
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "buildings-3d",
+      "type": "fill-extrusion",
+      "source": "tilezen",
+      "source-layer": "buildings",
+      "minzoom": 15,
+      "maxzoom": 20,
+      "layout": {},
+      "paint": {
+        "fill-extrusion-height": 7,
+        "fill-extrusion-base": 0,
+        "fill-extrusion-opacity": 0.7,
+        "fill-extrusion-color": {
+          "stops": [
+            [
+              15,
+              "rgba(230, 230, 230, 1)"
+            ],
+            [
+              20,
+              "rgba(160, 160, 160, 1)"
             ]
           ]
         }
@@ -456,7 +483,7 @@
           "base": 1.55,
           "stops": [
             [
-              4,
+              5,
               1
             ],
             [
@@ -491,8 +518,8 @@
           "base": 1.55,
           "stops": [
             [
-              8,
-              3
+              5,
+              1
             ],
             [
               20,
@@ -526,8 +553,8 @@
           "base": 1.55,
           "stops": [
             [
-              8,
-              3
+              5,
+              1
             ],
             [
               20,
@@ -561,8 +588,8 @@
           "base": 1.55,
           "stops": [
             [
-              8,
-              3
+              5,
+              1
             ],
             [
               20,
@@ -598,8 +625,8 @@
           "base": 1.55,
           "stops": [
             [
-              4,
-              1.5
+              5,
+              1
             ],
             [
               20,
@@ -745,8 +772,8 @@
           "base": 1.55,
           "stops": [
             [
-              8,
-              2
+              5,
+              0.5
             ],
             [
               20,
@@ -780,8 +807,8 @@
           "base": 1.55,
           "stops": [
             [
-              8,
-              2
+              5,
+              0.5
             ],
             [
               20,
@@ -815,8 +842,8 @@
           "base": 1.55,
           "stops": [
             [
-              8,
-              2
+              5,
+              0.5
             ],
             [
               20,
@@ -852,8 +879,8 @@
           "base": 1.55,
           "stops": [
             [
-              4,
-              1
+              5,
+              0.5
             ],
             [
               20,

--- a/osm2pgsql.style
+++ b/osm2pgsql.style
@@ -90,6 +90,7 @@ node,way   brand        text         linear
 node,way   bridge       text         linear
 node,way   boundary     text         linear
 node,way   building     text         polygon
+node,way   building:levels text      polygon
 node       capital      text         linear
 node,way   construction text         linear
 node,way   covered      text         linear

--- a/queries/roads/z1a.pgsql
+++ b/queries/roads/z1a.pgsql
@@ -1,5 +1,5 @@
 SELECT
-  way AS __geometry__,
+  st_linemerge(st_collect(way)) AS __geometry__,
   (
     CASE
       WHEN highway IS NOT NULL
@@ -26,3 +26,13 @@ WHERE
    OR
    (railway = 'rail' AND service IS NULL)
   )
+GROUP BY
+  (
+    CASE
+      WHEN highway IS NOT NULL
+        THEN highway
+      WHEN railway IS NOT NULL
+        THEN coalesce(service, railway)
+    END
+  ) AS kind,
+  ref

--- a/queries/roads/z2.pgsql
+++ b/queries/roads/z2.pgsql
@@ -1,5 +1,5 @@
 SELECT
-  way AS __geometry__,
+  st_linemerge(st_collect(way)) AS __geometry__,
   (
     CASE
       WHEN highway IS NOT NULL
@@ -27,3 +27,14 @@ WHERE
    OR
    (railway = 'rail' AND service IS NULL)
   )
+GROUP BY
+  (
+    CASE
+      WHEN highway IS NOT NULL
+        THEN highway
+      WHEN railway IS NOT NULL
+        THEN coalesce(service, railway)
+    END
+  ) AS kind,
+  name,
+  ref

--- a/queries/roads/z2a.pgsql
+++ b/queries/roads/z2a.pgsql
@@ -1,5 +1,5 @@
 SELECT
-  way AS __geometry__,
+  st_linemerge(st_collect(way)) AS __geometry__,
   (
     CASE
       WHEN highway IS NOT NULL
@@ -32,3 +32,16 @@ WHERE
    OR
    aeroway IN ('runway', 'taxiway', 'parking_position')
   )
+GROUP BY
+  (
+    CASE
+      WHEN highway IS NOT NULL
+        THEN highway
+      WHEN railway IS NOT NULL
+        THEN coalesce(service, railway)
+      WHEN aeroway IS NOT NULL
+        THEN aeroway
+    END
+  ) AS kind,
+  name,
+  ref

--- a/queries/water/z10.pgsql
+++ b/queries/water/z10.pgsql
@@ -51,4 +51,4 @@ WHERE
     amenity = 'swimming_pool' OR
     leisure = 'swimming_pool'
   ) AND
-  way_area >= 1000000
+  way_area >= 500000

--- a/queries/water/z11.pgsql
+++ b/queries/water/z11.pgsql
@@ -53,4 +53,4 @@ WHERE
     amenity = 'swimming_pool' OR
     leisure = 'swimming_pool'
   ) AND
-  way_area >= 500000
+  way_area >= 100000

--- a/queries/water/z12.pgsql
+++ b/queries/water/z12.pgsql
@@ -53,4 +53,4 @@ WHERE
     amenity = 'swimming_pool' OR
     leisure = 'swimming_pool'
   ) AND
-  way_area >= 500000
+  way_area >= 100000

--- a/queries/water/z13.pgsql
+++ b/queries/water/z13.pgsql
@@ -53,4 +53,4 @@ WHERE
     amenity = 'swimming_pool' OR
     leisure = 'swimming_pool'
   ) AND
-  way_area >= 100000
+  way_area >= 50000

--- a/queries/water/z14.pgsql
+++ b/queries/water/z14.pgsql
@@ -53,4 +53,4 @@ WHERE
     amenity = 'swimming_pool' OR
     leisure = 'swimming_pool'
   ) AND
-  way_area >= 50000
+  way_area >= 10000

--- a/tiles.cfg
+++ b/tiles.cfg
@@ -241,6 +241,7 @@
         "kwargs": {
           "names": [
             "boundaries",
+            "protected",
             "coastline",
             "water",
             "roads",


### PR DESCRIPTION
1. Prie „all“ pridėtas pamirštas nacionalinių parkų sluoksnis „protected“.
2. Sumažinti vandens ploto apribojimai skirtinguose masteliuose (bus daugiau vandens).
3. Atšviežinta vandens plotų, kelių išvaizda, pridėtas fiksuoto aukščio 3d pastatų vaizdavimas.
4. Pridėtas laukas building:levels, kad ateityje būtų galima skaičiuoti pastato aukštį pagal OSM duomenis.