### PR TITLE
Nacionaliniai/regioniniai parkai. Pastatų aukščio informacija.

### DIFF
--- a/demo/styles/map.json
+++ b/demo/styles/map.json
@@ -336,6 +336,77 @@
       }
     },
     {
+      "id": "boundary-national-park-outline",
+      "type": "line",
+      "source": "tilezen",
+      "source-layer": "protected",
+      "minzoom": 0,
+      "maxzoom": 20,
+      "filter": [
+        "all",
+        [
+          "==",
+          "kind",
+          "national_park"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(11, 119, 14, 1)",
+        "line-dasharray": [
+          2,
+          4
+        ],
+        "line-width": {
+          "stops": [
+            [
+              8,
+              1
+            ],
+            [
+              18,
+              3
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "boundary-national-park",
+      "type": "fill",
+      "source": "tilezen",
+      "source-layer": "protected",
+      "minzoom": 7,
+      "maxzoom": 12,
+      "filter": [
+        "all",
+        [
+          "==",
+          "kind",
+          "national_park"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "fill-color": {
+          "stops": [
+            [
+              7,
+              "rgba(34, 183, 44, 0.2)"
+            ],
+            [
+              12,
+              "rgba(34, 183, 44, 0)"
+            ]
+          ]
+        }
+      }
+    },
+    {
       "id": "boundary-country",
       "type": "line",
       "source": "tilezen",

--- a/queries/buildings/z1.pgsql
+++ b/queries/buildings/z1.pgsql
@@ -1,7 +1,8 @@
 SELECT
   way AS __geometry__,
   building AS kind,
-  coalesce(name, "addr:housename", "addr:housenumber") AS name
+  coalesce(name, "addr:housename", "addr:housenumber") AS name,
+  coalesce(cast(height as integer), coalesce(cast("building:levels" as integer), 2) * 3) AS height
 FROM
   planet_osm_polygon
 WHERE

--- a/queries/water/z14.pgsql
+++ b/queries/water/z14.pgsql
@@ -55,22 +55,5 @@ WHERE
   ) AND
   way_area >= 10000
 GROUP BY
-  (
-    CASE
-      WHEN waterway = 'riverbank'
-        THEN 'riverbank'
-      WHEN waterway = 'dock'
-        THEN 'dock'
-      WHEN "natural" = 'water'
-        THEN 'water'
-      WHEN "natural" = 'bay'
-        THEN 'bay'
-      WHEN landuse = 'basin'
-        THEN 'basin'
-      WHEN landuse = 'reservoir'
-        THEN 'lake'
-      WHEN amenity = 'swimming_pool' OR leisure = 'swimming_pool'
-        THEN 'swimming_pool'
-    END
-  ),
+  kind,
   coalesce("name:lt", name)

--- a/queries/water/z14.pgsql
+++ b/queries/water/z14.pgsql
@@ -22,7 +22,7 @@ WHERE
 UNION ALL
 
 SELECT
-  way AS __geometry__,
+  st_union(way) AS __geometry__,
   (
     CASE
       WHEN waterway = 'riverbank'
@@ -54,3 +54,23 @@ WHERE
     leisure = 'swimming_pool'
   ) AND
   way_area >= 10000
+GROUP BY
+  (
+    CASE
+      WHEN waterway = 'riverbank'
+        THEN 'riverbank'
+      WHEN waterway = 'dock'
+        THEN 'dock'
+      WHEN "natural" = 'water'
+        THEN 'water'
+      WHEN "natural" = 'bay'
+        THEN 'bay'
+      WHEN landuse = 'basin'
+        THEN 'basin'
+      WHEN landuse = 'reservoir'
+        THEN 'lake'
+      WHEN amenity = 'swimming_pool' OR leisure = 'swimming_pool'
+        THEN 'swimming_pool'
+    END
+  ),
+  coalesce("name:lt", name)

--- a/tiles.cfg
+++ b/tiles.cfg
@@ -176,7 +176,8 @@
             "15": "queries/protected/z0.pgsql",
             "16": "queries/protected/z0.pgsql"
           },
-          "srid": 3857
+          "srid": 3857,
+          "padding": 5
         }
       }
     },


### PR DESCRIPTION
1. Standartiniame stiliuje pridėtas nacionalinių/regioninių parkų vaizdavimas.
2. Nacionaliniai/regioniai parkai (_protected_ sluoksnis) traukiami su _padding_, kad nesimatytų kaladėlių tarpų.
3. Db užklausos grąžina pastatų aukščio informaciją pagal OSM duomenis lauke _height_.
4. 14 mastelyje uždėtas bandomasis vandens poligonų sujungimas. Turėtų spręsti https://github.com/openmaplt/vector-map/issues/23