### PR TITLE
Padidintas maksimalus ortofoto mastelis

### DIFF
--- a/demo/styles/hybrid.json
+++ b/demo/styles/hybrid.json
@@ -29,7 +29,7 @@
       "type": "raster",
       "source": "orto",
       "minzoom": 0,
-      "maxzoom": 18
+      "maxzoom": 20
     },
     {
       "id": "country-boundary",


### PR DESCRIPTION
Pataisoma klaida, kai maksimaliai priartinus hibridinį sluoksnį vietoje ortofoto paišomas baltas plotas.