### PR TITLE
Sulieti administracnes ribas

### DIFF
--- a/queries/boundaries/z10.pgsql
+++ b/queries/boundaries/z10.pgsql
@@ -1,5 +1,5 @@
 SELECT
-  way AS __geometry__,
+  st_linemerge(st_collect(way)) AS __geometry__,
   admin_level,
   (
     CASE
@@ -18,3 +18,4 @@ FROM
 WHERE
   way && !bbox! AND
   boundary IN ('administrative') AND admin_level IN ('2', '4', '6', '8')
+GROUP BY admin_level, kind

--- a/queries/boundaries/z8.pgsql
+++ b/queries/boundaries/z8.pgsql
@@ -1,5 +1,5 @@
 SELECT
-  way AS __geometry__,
+  st_linemerge(st_collect(way)) AS __geometry__,
   admin_level,
   (
     CASE
@@ -14,3 +14,4 @@ FROM
 WHERE
   way && !bbox! AND
   boundary = 'administrative' AND admin_level IN ('2', '4')
+GROUP BY admin_level, kind


### PR DESCRIPTION
Administracinių ribų linijos kartodavosi, po kartą kiekvienai pusei (pvz. ta pati linija eina kaip Lietuvos administracinė riba, ir lygiai ten pat - kaip Latvijos). Suliejus administracines linijas bus mažesnės kaladėlės ir administracinių linijų vaizdas bus gražesnis.