### PR TITLE
Turizmo/lankytinus objektus rodyti anksčiau

### DIFF
--- a/demo/styles/hybrid.json
+++ b/demo/styles/hybrid.json
@@ -212,6 +212,58 @@
       }
     },
     {
+      "id": "road-oneway",
+      "type": "line",
+      "source": "osm",
+      "source-layer": "roads",
+      "minzoom": 8,
+      "filter": [
+        "all",
+        [
+          "in",
+          "kind",
+          "residential",
+          "unclassified",
+          "living_street",
+          "service",
+          "trunk",
+          "trunk_link",
+          "primary",
+          "primary_link",
+          "secondary",
+          "secondary_link",
+          "tertiary",
+          "tertiary_link"
+        ],
+        [
+          "==",
+          "oneway",
+          "yes"
+        ]
+      ],
+      "layout": {
+        "line-join": "round",
+        "line-cap": "round"
+      },
+      "paint": {
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [
+              4,
+              0.25
+            ],
+            [
+              20,
+              30
+            ]
+          ]
+        },
+        "line-opacity": 0.5,
+        "line-pattern": "oneway"
+      }
+    },
+    {
       "id": "link-bridge",
       "type": "line",
       "source": "osm",

--- a/demo/styles/map.json
+++ b/demo/styles/map.json
@@ -934,8 +934,9 @@
       "source": "tilezen",
       "source-layer": "roads",
       "minzoom": 16,
+      "maxzoom": 24,
       "filter": [
-        "any",
+        "all",
         [
           "in",
           "kind",

--- a/queries/poi/z15.pgsql
+++ b/queries/poi/z15.pgsql
@@ -1,0 +1,172 @@
+SELECT
+  way AS __geometry__,
+  name,
+  (
+    CASE
+    WHEN amenity = 'fuel'
+      THEN 'fuel'
+    WHEN amenity = 'place_of_worship'
+      THEN 'place_of_worship'
+
+    WHEN man_made = 'tower' and "tower:type" is not null and tourism in ('attraction', 'viewpoint', 'museum') and coalesce(access, 'yes') != 'no'
+      THEN 'marker' -- TODO: tower
+
+    WHEN tourism = 'attraction' and "attraction:type" = 'hiking_route'
+      THEN 'marker' -- TODO: hiking route
+    WHEN tourism = 'information'
+      THEN 'information'
+    WHEN tourism in ('camp_site', 'caravan_site')
+      THEN 'campsite'
+    WHEN tourism in ('chalet', 'hostel', 'motel', 'guest_house')
+      THEN 'home' -- TODO: split, fix icon
+    WHEN tourism = 'hotel'
+      THEN 'lodging'
+    WHEN tourism = 'museum'
+      THEN 'museum'
+    WHEN tourism = 'picnic_site'
+      THEN 'picnic_site'
+    WHEN tourism = 'viewpoint'
+      THEN 'viewpoint'
+
+    WHEN historic = 'archaeological_site' and site_type = 'fortification'
+      THEN 'hillfort'
+    WHEN historic in ('monument', 'memorial')
+      THEN 'marker' -- TODO: memorial
+    WHEN historic = 'archaeological_site' and site_type = 'tumulus'
+      THEN 'tumulus'
+    WHEN historic = 'manor'
+      THEN 'marker' -- TODO: manor
+    WHEN historic = 'monastery'
+      THEN 'marker' -- TODO: monastery
+
+    WHEN tourism = 'attraction'
+      THEN 'attraction'
+    END
+  ) AS kind,
+  official_name,
+  alt_name,
+  opening_hours,
+  website,
+  image,
+  "ref:lt:kpd" AS heritage,
+  height,
+  wikipedia,
+  fee,
+  email,
+  phone,
+  "addr:city" AS city,
+  "addr:street" AS street,
+  "addr:housenumber" AS housenumber
+FROM
+  planet_osm_point
+WHERE
+  way && !bbox! AND
+  (
+    amenity IN ('fuel',
+                'place_of_worship') OR
+    tourism IN ('attraction',
+                'camp_site',
+                'caravan_site',
+                'chalet',
+                'hostel',
+                'motel',
+                'guest_house',
+                'hotel',
+                'museum',
+                'picnic_site',
+                'viewpoint') OR
+    (tourism = 'information' and information = 'office') OR
+    historic IN ('archaeological_site',
+                 'monument',
+                 'memorial',
+                 'manor',
+                 'monastery')
+  )
+
+UNION ALL
+
+SELECT
+  st_centroid(way) AS __geometry__,
+  name,
+  (
+    CASE
+    WHEN amenity = 'fuel'
+      THEN 'fuel'
+    WHEN amenity = 'place_of_worship'
+      THEN 'place_of_worship'
+
+    WHEN man_made = 'tower' and "tower:type" is not null and tourism in ('attraction', 'viewpoint', 'museum') and coalesce(access, 'yes') != 'no'
+      THEN 'marker' -- TODO: tower
+
+    WHEN tourism = 'attraction' and "attraction:type" = 'hiking_route'
+      THEN 'marker' -- TODO: hiking route
+    WHEN tourism = 'information'
+      THEN 'information'
+    WHEN tourism in ('camp_site', 'caravan_site')
+      THEN 'campsite'
+    WHEN tourism in ('chalet', 'hostel', 'motel', 'guest_house')
+      THEN 'home' -- TODO: split, fix icon
+    WHEN tourism = 'hotel'
+      THEN 'lodging'
+    WHEN tourism = 'museum'
+      THEN 'museum'
+    WHEN tourism = 'picnic_site'
+      THEN 'picnic_site'
+    WHEN tourism = 'viewpoint'
+      THEN 'viewpoint'
+
+    WHEN historic = 'archaeological_site' and site_type = 'fortification'
+      THEN 'marker' -- TODO: hillfort
+    WHEN historic in ('monument', 'memorial')
+      THEN 'marker' -- TODO: memorial
+    WHEN historic = 'archaeological_site' and site_type = 'tumulus'
+      THEN 'marker' -- TODO: tumulus
+    WHEN historic = 'manor'
+      THEN 'marker' -- TODO: manor
+    WHEN historic = 'monastery'
+      THEN 'marker' -- TODO: monastery
+
+    WHEN tourism = 'attraction'
+      THEN 'attraction'
+
+    END
+  ) AS kind,
+  official_name,
+  alt_name,
+  opening_hours,
+  website,
+  image,
+  "ref:lt:kpd" AS heritage,
+  height,
+  wikipedia,
+  fee,
+  email,
+  phone,
+  "addr:city" AS city,
+  "addr:street" AS street,
+  "addr:housenumber" AS housenumber
+FROM
+  planet_osm_polygon
+WHERE
+  way && !bbox! AND
+  (
+    amenity IN ('fuel',
+                'place_of_worship') OR
+    tourism IN ('attraction',
+                'camp_site',
+                'caravan_site',
+                'chalet',
+                'hostel',
+                'motel',
+                'guest_house',
+                'hotel',
+                'museum',
+                'picnic_site',
+                'viewpoint') OR
+    (tourism = 'information' and information = 'office') OR
+    historic IN ('archaeological_site',
+                 'monument',
+                 'memorial',
+                 'manor',
+                 'monastery')
+  )

--- a/queries/poi/z16.pgsql
+++ b/queries/poi/z16.pgsql
@@ -63,8 +63,6 @@ SELECT
 
     WHEN tourism = 'attraction' and "attraction:type" = 'hiking_route'
       THEN 'marker' -- TODO: hiking route
-    WHEN tourism = 'attraction'
-      THEN 'attraction'
     WHEN tourism = 'information'
       THEN 'information'
     WHEN tourism in ('camp_site', 'caravan_site')
@@ -90,6 +88,9 @@ SELECT
       THEN 'marker' -- TODO: manor
     WHEN historic = 'monastery'
       THEN 'marker' -- TODO: monastery
+
+    WHEN tourism = 'attraction'
+      THEN 'attraction'
 
     WHEN shop = 'alcohol'
       THEN 'alcohol_shop'
@@ -160,7 +161,8 @@ WHERE
                 'school',
                 'shelter',
                 'theatre',
-                'universite') OR
+                'townhall',
+                'university') OR
     tourism IN ('attraction',
                 'camp_site',
                 'caravan_site',
@@ -186,7 +188,12 @@ WHERE
                  'monument',
                  'memorial',
                  'manor',
-                 'monastery')
+                 'monastery') OR
+    office IN (
+              'government',
+              'notary',
+              'lawyer'
+    )
   )
 
 UNION ALL
@@ -256,8 +263,6 @@ SELECT
 
     WHEN tourism = 'attraction' and "attraction:type" = 'hiking_route'
       THEN 'marker' -- TODO: hiking route
-    WHEN tourism = 'attraction'
-      THEN 'attraction'
     WHEN tourism = 'information'
       THEN 'information'
     WHEN tourism in ('camp_site', 'caravan_site')
@@ -283,6 +288,9 @@ SELECT
       THEN 'marker' -- TODO: manor
     WHEN historic = 'monastery'
       THEN 'marker' -- TODO: monastery
+
+    WHEN tourism = 'attraction'
+      THEN 'attraction'
 
     WHEN shop = 'alcohol'
       THEN 'alcohol_shop'
@@ -353,7 +361,8 @@ WHERE
                 'school',
                 'shelter',
                 'theatre',
-                'universite') OR
+                'townhall',
+                'university') OR
     tourism IN ('attraction',
                 'camp_site',
                 'caravan_site',
@@ -379,5 +388,10 @@ WHERE
                  'monument',
                  'memorial',
                  'manor',
-                 'monastery')
+                 'monastery') OR
+    office IN (
+              'government',
+              'notary',
+              'lawyer'
+    )
   )

--- a/tiles.cfg
+++ b/tiles.cfg
@@ -122,6 +122,8 @@
             "database": "osm"
           },
           "queries": {
+            "14": "queries/poi/z15.pgsql"
+            "15": "queries/poi/z15.pgsql"
             "16": "queries/poi/z16.pgsql"
           },
           "srid": 3857,


### PR DESCRIPTION
1. Pataisytos kelios lankytinų vietų žymų reikšmės.
2. Pridėtos valstybinės įstaigos ir teisininkai.
3. Turistinės lankytinos vietos rodomos anksčiau, nes jos dažnai būna neapgyvendintose vietovėse, kur nežinant pozicijos iš anksto labai sunku ką nors rasti.