### PR TITLE
Vandens ir gyvenviečių rodymo patobulinimai pagrindiniame stiliuje

### DIFF
--- a/demo/styles/hybrid.json
+++ b/demo/styles/hybrid.json
@@ -226,14 +226,16 @@
           "unclassified",
           "living_street",
           "service",
-          "trunk",
-          "trunk_link",
-          "primary",
-          "primary_link",
+          "tertiary",
+          "tertiary_link",
           "secondary",
           "secondary_link",
-          "tertiary",
-          "tertiary_link"
+          "primary",
+          "primary_link",
+          "trunk",
+          "trunk_link",
+          "motorway",
+          "motorway_link"
         ],
         [
           "==",
@@ -695,7 +697,8 @@
         ],
         "symbol-placement": "line",
         "text-rotation-alignment": "auto",
-        "text-size": 13
+        "text-size": 13,
+        "visibility": "visible"
       },
       "paint": {
         "text-color": "rgba(0, 0, 0, 1)",

--- a/demo/styles/map.json
+++ b/demo/styles/map.json
@@ -929,50 +929,6 @@
       }
     },
     {
-      "id": "road-road-oneway",
-      "type": "line",
-      "source": "tilezen",
-      "source-layer": "roads",
-      "minzoom": 16,
-      "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "residential",
-          "unclassified",
-          "living_street"
-        ],
-        [
-          "==",
-          "oneway",
-          "yes"
-        ]
-      ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round",
-        "visibility": "visible"
-      },
-      "paint": {
-        "line-width": {
-          "base": 1.55,
-          "stops": [
-            [
-              4,
-              0.25
-            ],
-            [
-              20,
-              30
-            ]
-          ]
-        },
-        "line-pattern": "oneway"
-      }
-    },
-    {
       "id": "road-tertiary",
       "type": "line",
       "source": "tilezen",
@@ -1154,6 +1110,61 @@
           2
         ],
         "line-opacity": 0.5
+      }
+    },
+    {
+      "id": "road-oneway",
+      "type": "line",
+      "source": "tilezen",
+      "source-layer": "roads",
+      "minzoom": 16,
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        [
+          "in",
+          "kind",
+          "residential",
+          "unclassified",
+          "living_street",
+          "service",
+          "tertiary",
+          "tertiary_link",
+          "secondary",
+          "secondary_link",
+          "primary",
+          "primary_link",
+          "trunk",
+          "trunk_link",
+          "motorway",
+          "motorway_link"
+        ],
+        [
+          "==",
+          "oneway",
+          "yes"
+        ]
+      ],
+      "layout": {
+        "line-join": "round",
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [
+              4,
+              0.25
+            ],
+            [
+              20,
+              30
+            ]
+          ]
+        },
+        "line-pattern": "oneway"
       }
     },
     {

--- a/demo/styles/map.json
+++ b/demo/styles/map.json
@@ -310,7 +310,7 @@
       "layout": {},
       "paint": {
         "line-color": "rgba(149, 154, 212, 0.8)",
-        "line-width": 1.5
+        "line-width": 1
       }
     },
     {
@@ -658,7 +658,7 @@
         "line-cap": "round"
       },
       "paint": {
-        "line-color": "rgba(10, 10, 10, 1)",
+        "line-color": "rgba(112, 112, 112, 1)",
         "line-width": {
           "base": 1.55,
           "stops": [
@@ -1291,49 +1291,6 @@
       }
     },
     {
-      "id": "label-country",
-      "type": "symbol",
-      "source": "tilezen",
-      "source-layer": "places",
-      "maxzoom": 7,
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "Point"
-        ],
-        [
-          "==",
-          "kind",
-          "country"
-        ]
-      ],
-      "layout": {
-        "text-field": "{name}",
-        "text-font": [
-          "Roboto Condensed Italic"
-        ],
-        "text-max-width": 4,
-        "text-size": {
-          "stops": [
-            [
-              2,
-              24
-            ],
-            [
-              6,
-              21
-            ]
-          ]
-        }
-      },
-      "paint": {
-        "text-color": "#cb4b49",
-        "text-halo-color": "rgba(255,255,255,0.5)"
-      }
-    },
-    {
       "id": "label-state",
       "type": "symbol",
       "source": "tilezen",
@@ -1373,7 +1330,7 @@
         }
       },
       "paint": {
-        "text-color": "rgba(0, 0, 0, 1)",
+        "text-color": "rgba(136, 136, 136, 1)",
         "text-halo-color": "rgba(255,255, 255, 1)"
       }
     },
@@ -1406,171 +1363,6 @@
         "text-color": "rgba(11, 119, 14, 1)",
         "text-halo-color": "rgba(255, 255, 255, 1)",
         "text-halo-width": 1.5
-      }
-    },
-    {
-      "id": "label-city",
-      "type": "symbol",
-      "source": "tilezen",
-      "source-layer": "places",
-      "minzoom": 7,
-      "maxzoom": 14,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "city"
-        ]
-      ],
-      "layout": {
-        "text-field": "{name}",
-        "text-font": [
-          "Roboto Medium"
-        ],
-        "text-max-width": 10,
-        "text-letter-spacing": 0.1,
-        "text-size": 18
-      },
-      "paint": {
-        "text-color": "#384646",
-        "text-halo-color": "rgba(255,255,255,0.5)",
-        "icon-halo-width": 2,
-        "icon-halo-color": "rgba(255, 255, 255, 1)"
-      }
-    },
-    {
-      "id": "label-town",
-      "type": "symbol",
-      "source": "tilezen",
-      "source-layer": "places",
-      "minzoom": 8,
-      "maxzoom": 13,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "town",
-          "little_town",
-          "railway_station"
-        ]
-      ],
-      "layout": {
-        "text-field": "{name}",
-        "text-font": [
-          "Roboto Regular"
-        ],
-        "text-max-width": 10,
-        "text-letter-spacing": 0.1,
-        "text-size": {
-          "stops": [
-            [
-              8,
-              12
-            ],
-            [
-              12,
-              13
-            ]
-          ]
-        },
-        "visibility": "visible"
-      },
-      "paint": {
-        "text-color": "#384646",
-        "text-halo-color": "rgba(255,255,255,0.5)",
-        "text-halo-width": 2,
-        "icon-halo-width": 0,
-        "icon-halo-color": "rgba(0, 0, 0, 0)"
-      }
-    },
-    {
-      "id": "label-village",
-      "type": "symbol",
-      "source": "tilezen",
-      "source-layer": "places",
-      "minzoom": 10,
-      "maxzoom": 15,
-      "filter": [
-        "any",
-        [
-          "==",
-          "kind",
-          "village"
-        ]
-      ],
-      "layout": {
-        "text-field": "{name}",
-        "text-font": [
-          "Roboto Regular"
-        ],
-        "text-max-width": 10,
-        "text-letter-spacing": 0.1,
-        "text-size": {
-          "stops": [
-            [
-              8,
-              8
-            ],
-            [
-              14,
-              13
-            ]
-          ]
-        },
-        "visibility": "visible"
-      },
-      "paint": {
-        "text-color": "#384646",
-        "text-halo-color": "rgba(255,255,255,1)",
-        "icon-halo-width": 0,
-        "icon-halo-color": "rgba(0, 0, 0, 0)",
-        "text-halo-width": 2
-      }
-    },
-    {
-      "id": "label-hamlet",
-      "type": "symbol",
-      "source": "tilezen",
-      "source-layer": "places",
-      "minzoom": 10,
-      "maxzoom": 15,
-      "filter": [
-        "any",
-        [
-          "==",
-          "kind",
-          "hamlet"
-        ]
-      ],
-      "layout": {
-        "text-field": "{name}",
-        "text-font": [
-          "Roboto Condensed Italic"
-        ],
-        "text-max-width": 10,
-        "text-letter-spacing": 0.1,
-        "text-size": {
-          "stops": [
-            [
-              8,
-              8
-            ],
-            [
-              14,
-              13
-            ]
-          ]
-        },
-        "visibility": "visible"
-      },
-      "paint": {
-        "text-color": "#384646",
-        "text-halo-color": "rgba(255,255,255,1)",
-        "icon-halo-width": 0,
-        "icon-halo-color": "rgba(0, 0, 0, 0)",
-        "text-halo-width": 2
       }
     },
     {
@@ -1622,6 +1414,173 @@
         "icon-halo-width": 2,
         "icon-halo-color": "rgba(255, 255, 255, 1)",
         "text-halo-width": 2
+      }
+    },
+    {
+      "id": "label-hamlet",
+      "type": "symbol",
+      "source": "tilezen",
+      "source-layer": "places",
+      "minzoom": 10,
+      "maxzoom": 15,
+      "filter": [
+        "any",
+        [
+          "==",
+          "kind",
+          "hamlet"
+        ]
+      ],
+      "layout": {
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Condensed Italic"
+        ],
+        "text-max-width": 10,
+        "text-letter-spacing": 0.1,
+        "text-size": {
+          "stops": [
+            [
+              8,
+              8
+            ],
+            [
+              14,
+              13
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#384646",
+        "text-halo-color": "rgba(255,255,255,1)",
+        "icon-halo-width": 0,
+        "icon-halo-color": "rgba(0, 0, 0, 0)",
+        "text-halo-width": 2
+      }
+    },
+    {
+      "id": "label-village",
+      "type": "symbol",
+      "source": "tilezen",
+      "source-layer": "places",
+      "minzoom": 10,
+      "maxzoom": 15,
+      "filter": [
+        "any",
+        [
+          "==",
+          "kind",
+          "village"
+        ]
+      ],
+      "layout": {
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular"
+        ],
+        "text-max-width": 10,
+        "text-letter-spacing": 0.1,
+        "text-size": {
+          "stops": [
+            [
+              8,
+              8
+            ],
+            [
+              14,
+              13
+            ]
+          ]
+        },
+        "visibility": "visible",
+        "symbol-spacing": 250,
+        "text-padding": 5
+      },
+      "paint": {
+        "text-color": "#384646",
+        "text-halo-color": "rgba(255,255,255,1)",
+        "icon-halo-width": 0,
+        "icon-halo-color": "rgba(0, 0, 0, 0)",
+        "text-halo-width": 2
+      }
+    },
+    {
+      "id": "label-town",
+      "type": "symbol",
+      "source": "tilezen",
+      "source-layer": "places",
+      "minzoom": 7,
+      "maxzoom": 13,
+      "filter": [
+        "all",
+        [
+          "in",
+          "kind",
+          "town",
+          "little_town",
+          "railway_station"
+        ]
+      ],
+      "layout": {
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Medium"
+        ],
+        "text-max-width": 10,
+        "text-letter-spacing": 0.1,
+        "text-size": {
+          "stops": [
+            [
+              8,
+              12
+            ],
+            [
+              12,
+              13
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#384646",
+        "text-halo-color": "rgba(255,255,255,0.5)",
+        "text-halo-width": 2,
+        "icon-halo-width": 0,
+        "icon-halo-color": "rgba(0, 0, 0, 0)"
+      }
+    },
+    {
+      "id": "label-city",
+      "type": "symbol",
+      "source": "tilezen",
+      "source-layer": "places",
+      "minzoom": 7,
+      "maxzoom": 14,
+      "filter": [
+        "all",
+        [
+          "in",
+          "kind",
+          "city"
+        ]
+      ],
+      "layout": {
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Medium"
+        ],
+        "text-max-width": 10,
+        "text-letter-spacing": 0.1,
+        "text-size": 18
+      },
+      "paint": {
+        "text-color": "#384646",
+        "text-halo-color": "rgba(255,255,255,0.5)",
+        "icon-halo-width": 2,
+        "icon-halo-color": "rgba(255, 255, 255, 1)"
       }
     },
     {

--- a/queries/places/z10.pgsql
+++ b/queries/places/z10.pgsql
@@ -32,3 +32,5 @@ WHERE
   name IS NOT NULL AND
   ("natural" = 'water' OR landuse = 'reservoir') AND
   way_area >= 1000000
+ORDER BY
+  coalesce(population, 0) desc

--- a/queries/places/z11.pgsql
+++ b/queries/places/z11.pgsql
@@ -32,3 +32,5 @@ WHERE
   name IS NOT NULL AND
   ("natural" = 'water' OR landuse = 'reservoir') AND
   way_area >= 500000
+ORDER BY
+  coalesce(population, 0) desc

--- a/queries/places/z12.pgsql
+++ b/queries/places/z12.pgsql
@@ -18,6 +18,8 @@ WHERE
   way && !bbox! AND
   name IS NOT NULL AND
   place IN ('city', 'town', 'village')
+ORDER BY
+  coalesce(population, 0) desc
 
 UNION ALL
 

--- a/queries/places/z8.pgsql
+++ b/queries/places/z8.pgsql
@@ -23,17 +23,3 @@ WHERE
   )
 ORDER BY
   coalesce(population, 0) desc
-
-UNION ALL
-
-SELECT
-  ST_PointOnSurface(way) AS __geometry__,
-  coalesce("name:lt", name) AS name,
-  website AS website
-FROM
-  planet_osm_polygon
-WHERE
-  way && !bbox! AND
-  name IS NOT NULL AND
-  boundary = 'national_park' AND
-  way_area >= 1000000

--- a/queries/places/z8.pgsql
+++ b/queries/places/z8.pgsql
@@ -19,5 +19,21 @@ WHERE
   name IS NOT NULL AND
   (
     place IN ('country', 'state', 'city') OR
-    (place = 'town' AND rank = '0')
+    (place = 'town' AND rank in ('0', '10'))
   )
+ORDER BY
+  coalesce(population, 0) desc
+
+UNION ALL
+
+SELECT
+  ST_PointOnSurface(way) AS __geometry__,
+  coalesce("name:lt", name) AS name,
+  website AS website
+FROM
+  planet_osm_polygon
+WHERE
+  way && !bbox! AND
+  name IS NOT NULL AND
+  boundary = 'national_park' AND
+  way_area >= 1000000

--- a/queries/places/z9.pgsql
+++ b/queries/places/z9.pgsql
@@ -23,17 +23,3 @@ WHERE
   )
 ORDER BY
   coalesce(population, 0) desc
-
-UNION ALL
-
-SELECT
-  ST_PointOnSurface(way) AS __geometry__,
-  coalesce("name:lt", name) AS name,
-  website AS website
-FROM
-  planet_osm_polygon
-WHERE
-  way && !bbox! AND
-  name IS NOT NULL AND
-  boundary = 'national_park' AND
-  way_area >= 1000000

--- a/queries/places/z9.pgsql
+++ b/queries/places/z9.pgsql
@@ -19,5 +19,21 @@ WHERE
   name IS NOT NULL AND
   (
     place IN ('country', 'state', 'city') OR
-    (place = 'town' AND rank = '0')
+    (place = 'town' AND rank in ('0', '10'))
   )
+ORDER BY
+  coalesce(population, 0) desc
+
+UNION ALL
+
+SELECT
+  ST_PointOnSurface(way) AS __geometry__,
+  coalesce("name:lt", name) AS name,
+  website AS website
+FROM
+  planet_osm_polygon
+WHERE
+  way && !bbox! AND
+  name IS NOT NULL AND
+  boundary = 'national_park' AND
+  way_area >= 1000000

--- a/queries/poi/z7.pgsql
+++ b/queries/poi/z7.pgsql
@@ -1,0 +1,12 @@
+SELECT
+  ST_PointOnSurface(way) AS __geometry__,
+  coalesce("name:lt", name) AS name,
+  website,
+  wikipedia
+FROM
+  planet_osm_polygon
+WHERE
+  way && !bbox! AND
+  name IS NOT NULL AND
+  boundary = 'national_park' AND
+  way_area >= 1000000

--- a/queries/routes/z15.pgsql
+++ b/queries/routes/z15.pgsql
@@ -1,0 +1,14 @@
+SELECT
+  st_linemerge(st_collect(way)) AS __geometry__,
+  route AS kind,
+  network,
+  name,
+  distance
+FROM
+  planet_osm_line
+WHERE
+  way && !bbox! AND
+  route IN ('hiking') AND
+  network = 'lwn'
+GROUP BY
+  highway, ref

--- a/queries/water/z8.pgsql
+++ b/queries/water/z8.pgsql
@@ -1,0 +1,40 @@
+SELECT
+  way AS __geometry__,
+  (
+    CASE
+      WHEN waterway = 'river'
+        THEN 'river'
+    END
+  ) AS kind,
+  coalesce("name:lt", name) AS name
+FROM
+  planet_osm_line
+WHERE
+  way && !bbox! AND
+  waterway = 'river'
+
+UNION ALL
+
+SELECT
+  st_union(way) AS __geometry__,
+  (
+    CASE
+      WHEN "natural" = 'water'
+        THEN 'water'
+      WHEN landuse = 'reservoir'
+        THEN 'lake'
+    END
+  ) AS kind,
+  coalesce("name:lt", name) AS name
+FROM
+  planet_osm_polygon
+WHERE
+  way && !bbox! AND
+  (
+    "natural" = 'water' OR
+    landuse = 'reservoir' OR
+  ) AND
+  way_area >= 10000000
+GROUP BY
+  kind,
+  coalesce("name:lt", name)

--- a/tiles.cfg
+++ b/tiles.cfg
@@ -213,6 +213,27 @@
         }
       }
     },
+    "routes": {
+      "allowed origin": "*",
+      "provider": {
+        "class": "TileStache.Goodies.VecTiles:Provider",
+        "kwargs": {
+          "dbinfo": {
+            "host": "127.0.0.1",
+            "port": "5432",
+            "user": "osm",
+            "password": "osm",
+            "database": "osm"
+          },
+          "queries": {
+            "15": "queries/routes/z15.pgsql",
+            "16": "queries/routes/z15.pgsql"
+          },
+          "srid": 3857,
+          "padding": 5
+        }
+      }
+    },
     "coastline": {
       "allowed origin": "*",
       "provider": {

--- a/tiles.cfg
+++ b/tiles.cfg
@@ -46,6 +46,7 @@
             "database": "osm"
           },
           "queries": {
+            "8": "queries/water/z8.pgsql",
             "9": "queries/water/z9.pgsql",
             "10": "queries/water/z10.pgsql",
             "11": "queries/water/z11.pgsql",

--- a/tiles.cfg
+++ b/tiles.cfg
@@ -123,6 +123,9 @@
             "database": "osm"
           },
           "queries": {
+            "7": "queries/poi/z7.pgsql"
+            "8": "queries/poi/z8.pgsql"
+            "9": "queries/poi/z9.pgsql"
             "14": "queries/poi/z15.pgsql"
             "15": "queries/poi/z15.pgsql"
             "16": "queries/poi/z16.pgsql"


### PR DESCRIPTION
1. Vandens info traukti anksčiau.
2. Patobulintas gyvenviečių rodymas. Kreipiamas dėmesys į prioritetus (klasifikaciją, gyventojų skaičių), didesnis buferis (mažiau gyvenviečių etikečių sangrūdų).
3. Nacionalinių parkų centro taškų duomenys.