### PR TITLE
Pastatų užklausos pataisymas

### DIFF
--- a/queries/buildings/z1.pgsql
+++ b/queries/buildings/z1.pgsql
@@ -2,7 +2,7 @@ SELECT
   way AS __geometry__,
   building AS kind,
   coalesce(name, "addr:housename", "addr:housenumber") AS name,
-  coalesce(cast(height as integer), coalesce(cast("building:levels" as integer), 2) * 3) AS height
+  coalesce(cast(split_part(height, '.', 1) as integer), coalesce(cast("building:levels" as integer), 2) * 3) AS height
 FROM
   planet_osm_polygon
 WHERE


### PR DESCRIPTION
Apdorojama situacija, kai aukščio „height“ žyma turi nesveiką skaičių, t.y. skaičių, kurio negalima konvertuoti į integer tipą.