### PR TITLE
Pridėti papildomi žemėnaudos tipai. Mažesnis geležinkelio ryškumas.

### DIFF
--- a/demo/styles/map.json
+++ b/demo/styles/map.json
@@ -117,6 +117,29 @@
       }
     },
     {
+      "id": "landuse-sand",
+      "type": "fill",
+      "source": "tilezen",
+      "source-layer": "landuse",
+      "minzoom": 12,
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        [
+          "in",
+          "kind",
+          "sand"
+        ]
+      ],
+      "layout": {
+        "visibility": "none"
+      },
+      "paint": {
+        "fill-color": "rgba(242, 232, 141, 1)",
+        "fill-opacity": 1
+      }
+    },
+    {
       "id": "landuse-marsh",
       "type": "fill",
       "source": "tilezen",
@@ -132,6 +155,25 @@
       ],
       "paint": {
         "fill-color": "rgba(196, 243, 189, 1)",
+        "fill-opacity": 1
+      }
+    },
+    {
+      "id": "landuse-scrub",
+      "type": "fill",
+      "source": "tilezen",
+      "source-layer": "landuse",
+      "minzoom": 6,
+      "filter": [
+        "all",
+        [
+          "in",
+          "kind",
+          "scrub"
+        ]
+      ],
+      "paint": {
+        "fill-color": "rgba(146, 223, 134, 1)",
         "fill-opacity": 1
       }
     },
@@ -246,6 +288,25 @@
       }
     },
     {
+      "id": "landuse-allotments",
+      "type": "fill",
+      "source": "tilezen",
+      "source-layer": "landuse",
+      "minzoom": 6,
+      "filter": [
+        "all",
+        [
+          "in",
+          "kind",
+          "allotments"
+        ]
+      ],
+      "paint": {
+        "fill-color": "rgba(226, 211, 197, 1)",
+        "fill-opacity": 1
+      }
+    },
+    {
       "id": "landuse-commercial",
       "type": "fill",
       "source": "tilezen",
@@ -310,7 +371,18 @@
       "layout": {},
       "paint": {
         "line-color": "rgba(149, 154, 212, 0.8)",
-        "line-width": 1
+        "line-width": {
+          "stops": [
+            [
+              7,
+              0
+            ],
+            [
+              12,
+              1
+            ]
+          ]
+        }
       }
     },
     {
@@ -392,38 +464,6 @@
             ]
           ]
         }
-      }
-    },
-    {
-      "id": "boundary-state",
-      "type": "line",
-      "source": "tilezen",
-      "source-layer": "boundaries",
-      "minzoom": 6,
-      "maxzoom": 20,
-      "filter": [
-        "all",
-        [
-          "==",
-          "kind",
-          "region"
-        ]
-      ],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round",
-        "line-miter-limit": 1,
-        "line-round-limit": 1.05
-      },
-      "paint": {
-        "line-color": "rgba(119, 119, 119, 1)",
-        "line-width": 1,
-        "line-translate-anchor": "map",
-        "line-blur": 0,
-        "line-dasharray": [
-          1,
-          7
-        ]
       }
     },
     {
@@ -1248,7 +1288,7 @@
         "line-cap": "round"
       },
       "paint": {
-        "line-color": "rgba(0, 0, 0, 1)",
+        "line-color": "rgba(100, 100, 100, 1)",
         "line-width": {
           "base": 1.8,
           "stops": [

--- a/queries/landuse/z12.pgsql
+++ b/queries/landuse/z12.pgsql
@@ -24,6 +24,10 @@ SELECT
         THEN 'marsh'
       WHEN "natural" = 'wetland' AND "wetland" = 'swamp'
         THEN 'swamp'
+      WHEN "natural" in ('beach', 'sand')
+        THEN 'sand'
+      WHEN "natural" = 'scrub'
+        THEN 'scrub'
     END
   ) AS kind
 FROM
@@ -32,6 +36,6 @@ WHERE
   way && !bbox! AND
   (
     landuse IN ('forest', 'residential', 'commercial', 'industrial', 'meadow', 'farmland', 'allotments', 'cemetery', 'garages') OR
-   "natural" = 'wetland'
+   "natural" in ('wetland', 'beach', 'sand', 'scrub')
   ) AND
-  way_area >= 500000
+  way_area >= 100000

--- a/queries/landuse/z13.pgsql
+++ b/queries/landuse/z13.pgsql
@@ -26,6 +26,8 @@ SELECT
         THEN 'swamp'
       WHEN "natural" in ('beach', 'sand')
         THEN 'sand'
+      WHEN "natural" = 'scrub'
+        THEN 'scrub'
     END
   ) AS kind
 FROM
@@ -34,6 +36,6 @@ WHERE
   way && !bbox! AND
   (
     landuse IN ('forest', 'residential', 'commercial', 'industrial', 'meadow', 'farmland', 'allotments', 'cemetery', 'garages') OR
-   "natural" in ('wetland', 'sand', 'beach')
+   "natural" in ('wetland', 'sand', 'beach', 'scrub')
   ) AND
-  way_area >= 100000
+  way_area >= 50000

--- a/queries/landuse/z14.pgsql
+++ b/queries/landuse/z14.pgsql
@@ -26,6 +26,8 @@ SELECT
         THEN 'swamp'
       WHEN "natural" in ('beach', 'sand')
         THEN 'sand'
+      WHEN "natural" = 'scrub'
+        THEN 'scrub'
     END
   ) AS kind
 FROM
@@ -34,6 +36,6 @@ WHERE
   way && !bbox! AND
   (
     landuse IN ('forest', 'residential', 'commercial', 'industrial', 'meadow', 'farmland', 'allotments', 'cemetery', 'garages') OR
-   "natural" in ('wetland', 'sand', 'beach')
+   "natural" in ('wetland', 'sand', 'beach', 'scrub')
   ) AND
-  way_area >= 50000
+  way_area >= 10000

--- a/queries/landuse/z15.pgsql
+++ b/queries/landuse/z15.pgsql
@@ -26,6 +26,8 @@ SELECT
         THEN 'swamp'
       WHEN "natural" in ('beach', 'sand')
         THEN 'sand'
+      WHEN "natural" = 'scrub'
+        THEN 'scrub'
     END
   ) AS kind
 FROM
@@ -34,6 +36,6 @@ WHERE
   way && !bbox! AND
   (
     landuse IN ('forest', 'residential', 'commercial', 'industrial', 'meadow', 'farmland', 'allotments', 'cemetery', 'garages') OR
-   "natural" in ('wetland', 'sand', 'beach')
+   "natural" in ('wetland', 'sand', 'beach', 'scrub')
   ) AND
   way_area >= 2000

--- a/queries/landuse/z16.pgsql
+++ b/queries/landuse/z16.pgsql
@@ -26,6 +26,8 @@ SELECT
         THEN 'swamp'
       WHEN "natural" in ('beach', 'sand')
         THEN 'sand'
+      WHEN "natural" = 'scrub'
+        THEN 'scrub'
       WHEN leisure = 'park'
         THEN 'park'
     END
@@ -36,6 +38,6 @@ WHERE
   way && !bbox! AND
   (
     landuse IN ('forest', 'residential', 'commercial', 'industrial', 'meadow', 'farmland', 'allotments', 'cemetery', 'garages') OR
-   "natural" in ('wetland', 'sand', 'beach') OR
+   "natural" in ('wetland', 'sand', 'beach', 'scrub') OR
    leisure = 'park'
   )

--- a/queries/water/z12.pgsql
+++ b/queries/water/z12.pgsql
@@ -53,7 +53,7 @@ WHERE
     amenity = 'swimming_pool' OR
     leisure = 'swimming_pool'
   ) AND
-  way_area >= 100000
+  way_area >= 75000
 GROUP BY
   kind,
   coalesce("name:lt", name)


### PR DESCRIPTION
1. Pridėti krūmų duomenys.
2. Padidinti žemėnaudos dydžio apribojimai (per daug aiškiai matosi „per mažų“ poligonų skylės).
3. Į stilių pridėti: sodai, smėlis, krūmai.
4. Sumažintas geležinkelio ryškumas.
5. Išimtos apskričių ribos (išėmus apskričių pavadinimus jos klaidina naudotoją, nes neaišku, kas čia per ribos, plius jos nelabai neša kažkokią naudą).