### PR TITLE
dockerize project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 .idea
-/cache/*
+/cache
+/bin
+/include
+/lib
+/local
+/share
+pip-selfcheck.json
+*.pbf

--- a/README.md
+++ b/README.md
@@ -7,3 +7,23 @@ Vektorinis Lietuvos OpenStreetMap žemėlapis
 3. Žemėlapis, naudojantis vektorines kaladėles, stilius, kitas funkcionalumas.
 
 Wiki puslapiuose (https://github.com/openmaplt/vector-map/wiki) rasite informaciją apie tai, kokie sluoksniai grąžinami vektorinėse kaladėlėse: kokie objektai, kokiuose masteliuose, atributų sąrašas su galimomis reikšmėmis.
+
+## Docker
+
+Docker gali būti naudojamas lokalioje aplinkoje dirbant su vektoriniais duomenimis arba stiliais. Būtinas veikiantis `docker` ir `docker-compose`
+
+Paleidimas pirmą kartą arba po atnaujinimų:
+* `./bin/run.sh`
+* `./bin/init.sh`
+
+Visais kitais kartais:
+* `./bin/run.sh` paleisti servisus
+* `./bin/stop.sh` sustabdyti viską
+
+### Servisai
+
+* http://localhost žemėlapio puslapis
+* http://localhost:8888 [Maputnik stiliaus redaktorius](http://github.com/maputnik/editor)
+* localhost:5432 PostgreSQL duomenų bazė, user: osm, password: osm
+* http://localhost:8080 TileStache vektorinių kaladėlių servisas
+

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+if [ ! -e data.pbf ]; then
+	wget -O data.pbf http://osm.ramuno.lt/vilnius.pbf
+fi
+
+CONTAINER_DB=`docker-compose ps -q db`
+# install shp2pgsql
+docker exec $CONTAINER_DB sh -c 'apt update -qy && apt install -qy postgis'
+
+# load data
+docker run --rm -it -w /tmp/src -v `pwd`:/tmp/src --network "container:$CONTAINER_DB" -e PGPASSWORD=osm openmap/osm2pgsql:latest osm2pgsql -s -c -C 512 --multi-geometry -S db/osm2pgsql.style -d osm -U osm -H db data.pbf
+docker exec -u postgres $CONTAINER_DB sh -c 'psql osm -f /src/db/index.sql'
+docker exec -u postgres $CONTAINER_DB sh -c 'shp2pgsql -dDI -s 3857 /src/queries/coastline/coastline.shp | psql osm'

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker-compose up -d

--- a/bin/stop.sh
+++ b/bin/stop.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker-compose stop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: "2"
+
+services:
+  tiles:
+    image: pauliusm/tilestache
+    ports: ["8080:8080"]
+    links: ["db"]
+    environment:
+      PGHOST: db
+    volumes:
+      - "./tiles.cfg:/etc/tilestache/tilestache.cfg"
+      - "./queries:/etc/tilestache/queries"
+      - "/var/tilestache/cache"
+
+  db:
+    image: kartoza/postgis:9.6-2.4
+    ports: ["5432:5432"]
+    environment:
+      POSTGRES_DBNAME: osm
+      POSTGRES_USER: osm
+      POSTGRES_PASS: osm
+      ALLOW_IP_RANGE: 172.17.0.0/8
+    volumes:
+      - ".:/src"
+      - "/var/lib/postgresql"
+
+  web:
+    image: node:alpine
+    ports: ["80:8000"]
+    environment:
+      PUBLIC_PATH: "/var/www"
+    working_dir: "/srv/proxy"
+    volumes:
+      - "./demo:/var/www"
+      - "./proxy:/srv/proxy"
+    command: ["/srv/proxy/server.sh"]
+
+  maputnik:
+    image: maputnik/editor:latest
+    ports: ["8888:8888"]
+

--- a/proxy/.gitignore
+++ b/proxy/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/proxy/server.js
+++ b/proxy/server.js
@@ -1,0 +1,48 @@
+const fs = require('fs')
+const express = require('express');
+const app = express();
+const path = require('path');
+
+var public = process.env.PUBLIC_PATH || path.join(__dirname, 'public');
+var tilesUrl = process.env.TILES_URL || 'http://localhost:8080/all/{z}/{x}/{y}.pbf';
+
+// allow CORS
+app.all('*', (req, res, next) => {
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Methods', 'GET,HEAD');
+  res.header('Access-Control-Allow-Headers', 'X-Requested-With,Content-Type,Authorization');
+  next();
+});
+
+// rewrite source path to local webservice
+app.use('/styles/*\.json', function (req, res, next) {
+  var filename = path.join(public, req.baseUrl);
+  var style = JSON.parse(fs.readFileSync(filename, 'utf8'));
+  if ('sources' in style) {
+    for (var key in style.sources) {
+      var source = style.sources[key];
+      if (source.type != 'vector') {
+        continue;
+      }
+      if (!('tiles' in source)) {
+        return;
+      }
+      source.tiles = [tilesUrl];
+    };
+  }
+  res.json(style).end();
+});
+
+// serve static files
+app.use(express.static(public));
+app.use('/', function (req, res) {
+  res.sendFile(path.join(public, 'index.html'));
+});
+
+var server = app.listen(process.env.PORT || 8000);
+
+process.on('SIGINT', function () {
+  server.close();
+  process.exit();
+});
+

--- a/proxy/server.sh
+++ b/proxy/server.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+npm install express
+node ./server.js

--- a/tiles.cfg
+++ b/tiles.cfg
@@ -11,8 +11,6 @@
         "class": "TileStache.Goodies.VecTiles:Provider",
         "kwargs": {
           "dbinfo": {
-            "host": "127.0.0.1",
-            "port": "5432",
             "user": "osm",
             "password": "osm",
             "database": "osm"
@@ -39,8 +37,6 @@
         "class": "TileStache.Goodies.VecTiles:Provider",
         "kwargs": {
           "dbinfo": {
-            "host": "127.0.0.1",
-            "port": "5432",
             "user": "osm",
             "password": "osm",
             "database": "osm"
@@ -67,8 +63,6 @@
         "class": "TileStache.Goodies.VecTiles:Provider",
         "kwargs": {
           "dbinfo": {
-            "host": "127.0.0.1",
-            "port": "5432",
             "user": "osm",
             "password": "osm",
             "database": "osm"
@@ -95,8 +89,6 @@
         "class": "TileStache.Goodies.VecTiles:Provider",
         "kwargs": {
           "dbinfo": {
-            "host": "127.0.0.1",
-            "port": "5432",
             "user": "osm",
             "password": "osm",
             "database": "osm"
@@ -116,8 +108,6 @@
         "class": "TileStache.Goodies.VecTiles:Provider",
         "kwargs": {
           "dbinfo": {
-            "host": "127.0.0.1",
-            "port": "5432",
             "user": "osm",
             "password": "osm",
             "database": "osm"
@@ -142,8 +132,6 @@
         "class": "TileStache.Goodies.VecTiles:Provider",
         "kwargs": {
           "dbinfo": {
-            "host": "127.0.0.1",
-            "port": "5432",
             "user": "osm",
             "password": "osm",
             "database": "osm"
@@ -164,8 +152,6 @@
         "class": "TileStache.Goodies.VecTiles:Provider",
         "kwargs": {
           "dbinfo": {
-            "host": "127.0.0.1",
-            "port": "5432",
             "user": "osm",
             "password": "osm",
             "database": "osm"
@@ -193,8 +179,6 @@
         "class": "TileStache.Goodies.VecTiles:Provider",
         "kwargs": {
           "dbinfo": {
-            "host": "127.0.0.1",
-            "port": "5432",
             "user": "osm",
             "password": "osm",
             "database": "osm"
@@ -219,8 +203,6 @@
         "class": "TileStache.Goodies.VecTiles:Provider",
         "kwargs": {
           "dbinfo": {
-            "host": "127.0.0.1",
-            "port": "5432",
             "user": "osm",
             "password": "osm",
             "database": "osm"
@@ -240,8 +222,6 @@
         "class": "TileStache.Goodies.VecTiles:Provider",
         "kwargs": {
           "dbinfo": {
-            "host": "127.0.0.1",
-            "port": "5432",
             "user": "osm",
             "password": "osm",
             "database": "osm"
@@ -266,8 +246,6 @@
         "class": "TileStache.Goodies.VecTiles:Provider",
         "kwargs": {
           "dbinfo": {
-            "host": "127.0.0.1",
-            "port": "5432",
             "user": "osm",
             "password": "osm",
             "database": "osm"


### PR DESCRIPTION
@paumas nemažai pakeista, kad docker aplinkoj veiktų visi reikalingi dalykai, bet vis dar neišspręsta stiliaus problema. `demo/styles/*.json` failuose yra įrašyas sources url ir pagal mapbox gl js, negali būti reliatyvus, t.y. visada turi būti pilnas url. Todėl lokalus tilestache ir DB nenaudojami.

Ką galvoji apie build skriptus, kurių pagalba būtų įrašomi aplinkos adresai ir kiti nustatymai?