### PR TITLE
9, 10 mastelyje nerodomi smulkūs keliai

### DIFF
--- a/queries/roads/z1a.pgsql
+++ b/queries/roads/z1a.pgsql
@@ -19,10 +19,7 @@ WHERE
                'primary', 'primary_link',
                'secondary', 'secondary_link',
                'tertiary', 'tertiary_link',
-               'unclassified',
-               'living_street',
-               'residential',
-               'pedestrian')
+               'unclassified')
    OR
    (railway = 'rail' AND service IS NULL)
   )


### PR DESCRIPTION
9 ir 10 mastelyje išimami _living_street_, _pedestrian_ ir _residential_ keliai.
Atkreipiu dėmesį, kad *jungiamieji* keliai per gyvenamąsias zonas turėtų būti _unclassified_, kad gautųsi veikiantis kelių tinklas.