### PR TITLE
Grupuoti visus vandens plotus nepriklausomai nuo pavadinimų

### DIFF
--- a/queries/water/z10.pgsql
+++ b/queries/water/z10.pgsql
@@ -39,7 +39,7 @@ SELECT
         THEN 'swimming_pool'
     END
   ) AS kind,
-  coalesce("name:lt", name) AS name
+  null AS name
 FROM
   planet_osm_polygon
 WHERE
@@ -53,5 +53,4 @@ WHERE
   ) AND
   way_area >= 500000
 GROUP BY
-  kind,
-  coalesce("name:lt", name)
+  kind

--- a/queries/water/z11.pgsql
+++ b/queries/water/z11.pgsql
@@ -41,7 +41,7 @@ SELECT
         THEN 'swimming_pool'
     END
   ) AS kind,
-  coalesce("name:lt", name) AS name
+  null AS name
 FROM
   planet_osm_polygon
 WHERE
@@ -55,5 +55,4 @@ WHERE
   ) AND
   way_area >= 100000
 GROUP BY
-  kind,
-  coalesce("name:lt", name)
+  kind

--- a/queries/water/z12.pgsql
+++ b/queries/water/z12.pgsql
@@ -41,7 +41,7 @@ SELECT
         THEN 'swimming_pool'
     END
   ) AS kind,
-  coalesce("name:lt", name) AS name
+  null AS name
 FROM
   planet_osm_polygon
 WHERE
@@ -55,5 +55,4 @@ WHERE
   ) AND
   way_area >= 75000
 GROUP BY
-  kind,
-  coalesce("name:lt", name)
+  kind

--- a/queries/water/z13.pgsql
+++ b/queries/water/z13.pgsql
@@ -41,7 +41,7 @@ SELECT
         THEN 'swimming_pool'
     END
   ) AS kind,
-  coalesce("name:lt", name) AS name
+  null AS name
 FROM
   planet_osm_polygon
 WHERE
@@ -55,5 +55,4 @@ WHERE
   ) AND
   way_area >= 50000
 GROUP BY
-  kind,
-  coalesce("name:lt", name)
+  kind

--- a/queries/water/z14.pgsql
+++ b/queries/water/z14.pgsql
@@ -41,7 +41,7 @@ SELECT
         THEN 'swimming_pool'
     END
   ) AS kind,
-  coalesce("name:lt", name) AS name
+  null AS name
 FROM
   planet_osm_polygon
 WHERE
@@ -55,5 +55,4 @@ WHERE
   ) AND
   way_area >= 10000
 GROUP BY
-  kind,
-  coalesce("name:lt", name)
+  kind

--- a/queries/water/z15.pgsql
+++ b/queries/water/z15.pgsql
@@ -41,7 +41,7 @@ SELECT
         THEN 'swimming_pool'
     END
   ) AS kind,
-  coalesce("name:lt", name) AS name
+  null AS name
 FROM
   planet_osm_polygon
 WHERE
@@ -55,5 +55,4 @@ WHERE
   ) AND
   way_area >= 2000
 GROUP BY
-  kind,
-  coalesce("name:lt", name)
+  kind

--- a/queries/water/z16.pgsql
+++ b/queries/water/z16.pgsql
@@ -45,7 +45,7 @@ SELECT
         THEN 'swimming_pool'
     END
   ) AS kind,
-  coalesce("name:lt", name) AS name
+  null AS name
 FROM
   planet_osm_polygon
 WHERE
@@ -58,5 +58,4 @@ WHERE
     leisure = 'swimming_pool'
   )
 GROUP BY
-  kind,
-  coalesce("name:lt", name)
+  kind

--- a/queries/water/z8.pgsql
+++ b/queries/water/z8.pgsql
@@ -25,7 +25,7 @@ SELECT
         THEN 'lake'
     END
   ) AS kind,
-  coalesce("name:lt", name) AS name
+  null AS name
 FROM
   planet_osm_polygon
 WHERE
@@ -36,5 +36,4 @@ WHERE
   ) AND
   way_area >= 10000000
 GROUP BY
-  kind,
-  coalesce("name:lt", name)
+  kind

--- a/queries/water/z9.pgsql
+++ b/queries/water/z9.pgsql
@@ -39,7 +39,7 @@ SELECT
         THEN 'swimming_pool'
     END
   ) AS kind,
-  coalesce("name:lt", name) AS name
+  null AS name
 FROM
   planet_osm_polygon
 WHERE
@@ -53,5 +53,4 @@ WHERE
   ) AND
   way_area >= 5000000
 GROUP BY
-  kind,
-  coalesce("name:lt", name)
+  kind


### PR DESCRIPTION
Vandens pavadinimai iš poligonų dabartiniame _mapboxgl-js_ nepanaudojami, todėl nereikalingi. Nenaudojant pavadinimo teisingai susigrupuoja vandens plotai ir, jei naudojamas ploto apibrėžimas, jis nesukuria artefaktų vidury vandens.
Vandens pavadinimus reikia imti iš sluoksnio _names_.