### PR TITLE
Craft žemėlapio riktų pataisymai

### DIFF
--- a/demo/beer.html
+++ b/demo/beer.html
@@ -78,8 +78,6 @@
     }
     </style>
 </head>
-<!--
--->
 <body>
 <div id="map"></div>
 <!--div id="layers" class="pull-right btn-group hidden">

--- a/demo/beer.html
+++ b/demo/beer.html
@@ -26,7 +26,7 @@
         font: 12px/20px 'Helvetica Neue', Arial, Helvetica, sans-serif;
         font-weight: 600;
         position: absolute;
-        top: 50px;
+        top: 10px;
         right: 10px;
         z-index: 1;
         border-radius: 3px;
@@ -35,11 +35,11 @@
     }
 
     .filter-group input[type=checkbox]:first-child + label {
-        border-radius: 3px 3px 0 0;
+        border-radius: 7px 7px 0 0;
     }
 
     .filter-group label:last-child {
-        border-radius: 0 0 3px 3px;
+        border-radius: 0 0 7px 7px;
         border: none;
     }
 
@@ -60,7 +60,13 @@
         text-transform: capitalize;
     }
 
-    .filter-group input[type=checkbox] + label:hover,
+    @media (hover: hover) {
+      .filter-group input[type=checkbox] + label:hover {
+        background-color: #fff480;
+        color: #000;
+      }
+    }
+
     .filter-group input[type=checkbox]:checked + label {
         background-color: #fff480;
         color: #000;
@@ -72,11 +78,13 @@
     }
     </style>
 </head>
+<!--
+-->
 <body>
 <div id="map"></div>
-<div id="layers" class="pull-right btn-group hidden">
+<!--div id="layers" class="pull-right btn-group hidden">
     <button type="button" class="btn btn-default" data-style="beer_dark">Craft-alus</button>
-</div>
+</div-->
 <nav id='filter-group' class='filter-group'>
 <input type="checkbox" id="label-lager" checked="true" onChange="change()"><label for="label-lager">Lager</label>
 <input type="checkbox" id="label-ale"   checked="true" onChange="change()"><label for="label-ale"  >Ale</label>

--- a/demo/styles/beer_dark.json
+++ b/demo/styles/beer_dark.json
@@ -20,7 +20,7 @@
       ]
     }
   },
-  "sprite": "https://openmap.lt/sprites/craftbeer",
+  "sprite": "https://dev.openmap.lt/webgl/craftbeer",
   "glyphs": "https://orangemug.github.io/font-glyphs/glyphs/{fontstack}/{range}.pbf",
   "layers": [
     {
@@ -1266,14 +1266,6 @@
       "source-layer": "craftbeer",
       "minzoom": 10,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "style_ipa",
-          "y"
-        ]
-      ],
       "layout": {
         "text-field": "{name}",
         "text-size": 12,

--- a/demo/styles/beer_dark.json
+++ b/demo/styles/beer_dark.json
@@ -20,7 +20,7 @@
       ]
     }
   },
-  "sprite": "https://dev.openmap.lt/webgl/craftbeer",
+  "sprite": "https://openmap.lt/sprites/craftbeer",
   "glyphs": "https://orangemug.github.io/font-glyphs/glyphs/{fontstack}/{range}.pbf",
   "layers": [
     {


### PR DESCRIPTION
1. Pradinis filtras turi būti tuščias, nes tokia yra pradinė mygtukų būsena.
2. Mygtukai geltonuoja užvedus pelę tik neliečiamuose įrenginiuose.
3. Užkomentuotas „Craft“ sluoksnio pasirinkimo mygtukas, nes jis vienintelis (gal vėliau bus daugiau sluoksnių).