### PR TITLE
Laikina lentelė POI informacijos pagreitinimui

### DIFF
--- a/db/table_poi.sql
+++ b/db/table_poi.sql
@@ -1,0 +1,107 @@
+drop table poi_test;
+
+create table poi_test (
+  name text
+ ,amenity text
+ ,man_made text
+ ,"tower:type" text
+ ,tourism text
+ ,"attraction:type" text
+ ,access text
+ ,historic text
+ ,site_type text
+ ,shop text
+ ,information text
+ ,office text
+ ,official_name text
+ ,alt_name text
+ ,opening_hours text
+ ,website text
+ ,image text
+ ,"ref:lt:kpd" text
+ ,height text
+ ,wikipedia text
+ ,fee text
+ ,email text
+ ,phone text
+ ,"addr:city" text
+ ,"addr:street" text
+ ,"addr:housenumber" text
+);
+
+select addgeometrycolumn('poi_test', 'way', 3857, 'POINT', 2);
+
+insert into poi_test
+  select name
+        ,amenity
+        ,man_made
+        ,"tower:type"
+        ,tourism
+        ,"attraction:type"
+        ,access
+        ,historic
+        ,site_type
+        ,shop
+        ,information
+        ,office
+        ,official_name
+        ,alt_name
+        ,opening_hours
+        ,website
+        ,image
+        ,"ref:lt:kpd"
+        ,height
+        ,wikipedia
+        ,fee
+        ,email
+        ,phone
+        ,"addr:city"
+        ,"addr:street"
+        ,"addr:housenumber"
+        ,way
+    from planet_osm_point
+   where amenity is not null
+      or shop is not null
+      or real_ale is not null
+      or tourism is not null
+      or historic is not null
+      or office is not null
+  union
+  select name
+        ,amenity
+        ,man_made
+        ,"tower:type"
+        ,tourism
+        ,null --"attraction:type"
+        ,access
+        ,historic
+        ,site_type
+        ,shop
+        ,information
+        ,office
+        ,official_name
+        ,alt_name
+        ,opening_hours
+        ,website
+        ,image
+        ,"ref:lt:kpd"
+        ,height
+        ,wikipedia
+        ,fee
+        ,email
+        ,phone
+        ,"addr:city"
+        ,"addr:street"
+        ,"addr:housenumber"
+        ,st_centroid(way)
+    from planet_osm_polygon
+   where amenity is not null
+      or shop is not null
+      or real_ale is not null
+      or tourism is not null
+      or historic is not null
+      or office is not null;
+
+select count(1) from poi_test;
+
+vacuum analyze;

--- a/db/update.sh
+++ b/db/update.sh
@@ -85,6 +85,9 @@ if [ -s dirty_tiles ]; then
     tilestache-clean -c $TILESTACHE_CONFIG_FILE -l craftbeer -e pbf --tile-list delete_openmap_$DIRTY_FILE
     echo "Craftbeer generate expired " `date`
     tilestache-seed -c $TILESTACHE_CONFIG_FILE -x -l craftbeer -e pbf --tile-list generate_craftbeer_$DIRTY_FILE
+
+    echo "Re-creating poi table " `date`
+    psql osm < table_poi.sql
     echo "Done " `date`
 
     rm delete_openmap_$DIRTY_FILE generate_openmap_$DIRTY_FILE


### PR DESCRIPTION
POI elementams sukuriama atskira lenta, kuri užpildoma atnaujinus db. Tuo metu surašomi tik tie įrašai, kurie yra POI, tuo metu paskaičiuojamas poligoninių POI centroidas. Todėl vėlesnės užklausos iš šios vienos nedidelės lentelės yra daug greitesnės, nei užklausos iš didžiulių dviejų lentelių.