### PR TITLE
Administracinių ribų supaprastinimas

### DIFF
--- a/queries/boundaries/z10.pgsql
+++ b/queries/boundaries/z10.pgsql
@@ -1,5 +1,5 @@
 SELECT
-  st_linemerge(st_collect(way)) AS __geometry__,
+  way AS __geometry__,
   admin_level,
   (
     CASE
@@ -17,5 +17,6 @@ FROM
   planet_osm_line
 WHERE
   way && !bbox! AND
-  boundary IN ('administrative') AND admin_level IN ('2', '4', '6', '8')
-GROUP BY admin_level, kind
+  boundary = 'administrative' AND
+  ((admin_level = '2' AND name = 'Lietuva') or admin_level IN ('4', '6', '8')) AND
+  name not in ('Latgale', 'Kurzeme', 'Zemgale')

--- a/queries/boundaries/z8.pgsql
+++ b/queries/boundaries/z8.pgsql
@@ -16,4 +16,3 @@ WHERE
   boundary = 'administrative' AND
   ((admin_level = '2' AND name = 'Lietuva') or admin_level = '4') AND
   name not in ('Kurzeme', 'Latgale', 'Zemgale')
-/*GROUP BY admin_level, kind*/

--- a/queries/boundaries/z8.pgsql
+++ b/queries/boundaries/z8.pgsql
@@ -1,5 +1,5 @@
 SELECT
-  st_linemerge(st_collect(way)) AS __geometry__,
+  way AS __geometry__,
   admin_level,
   (
     CASE
@@ -13,5 +13,7 @@ FROM
   planet_osm_line
 WHERE
   way && !bbox! AND
-  boundary = 'administrative' AND admin_level IN ('2', '4')
-GROUP BY admin_level, kind
+  boundary = 'administrative' AND
+  ((admin_level = '2' AND name = 'Lietuva') or admin_level = '4') AND
+  name not in ('Kurzeme', 'Latgale', 'Zemgale')
+/*GROUP BY admin_level, kind*/

--- a/tiles.cfg
+++ b/tiles.cfg
@@ -143,7 +143,8 @@
             "9": "queries/boundaries/z8.pgsql",
             "10": "queries/boundaries/z10.pgsql"
           },
-          "srid": 3857
+          "srid": 3857,
+          "simplify": 0.5
         }
       }
     },


### PR DESCRIPTION
Panaikintas administracinių ribų suliejimas prieš paprastinimą, nes suliejus gaudavosi per didelė geometrija, kurios nebuvo galima apskritai supaprastinti.
Taip pat rodoma tik Lietuvos Respublikos riba, bei išimamos kelios užsienio administracinės ribos (kažkada reikėtų padaryti tikslų Lietuvai nepriklausančių objektų išvalymą).