### PR TITLE
Pagrindinio stiliaus atnaujinimai

### DIFF
--- a/demo/styles/map.json
+++ b/demo/styles/map.json
@@ -903,7 +903,7 @@
       "type": "fill",
       "source": "tilezen",
       "source-layer": "landuse",
-      "minzoom": 13,
+      "minzoom": 12,
       "maxzoom": 24,
       "filter": [
         "all",
@@ -1617,7 +1617,7 @@
           "Roboto Condensed Italic"
         ],
         "text-max-width": 10,
-        "text-letter-spacing": 0.1,
+        "text-letter-spacing": 0.05,
         "text-size": {
           "stops": [
             [
@@ -1641,126 +1641,32 @@
       }
     },
     {
-      "id": "label-village",
+      "id": "label-park",
       "type": "symbol",
       "source": "tilezen",
-      "source-layer": "places",
-      "minzoom": 10,
-      "maxzoom": 15,
-      "filter": [
-        "any",
-        [
-          "==",
-          "kind",
-          "village"
-        ]
-      ],
+      "source-layer": "poi",
+      "minzoom": 7,
+      "maxzoom": 11,
       "layout": {
         "text-field": "{name}",
-        "text-font": [
-          "Roboto Regular"
+        "text-size": 12,
+        "text-max-width": 9,
+        "text-anchor": "top",
+        "text-offset": [
+          0,
+          0.6
         ],
-        "text-max-width": 10,
-        "text-letter-spacing": 0.1,
-        "text-size": {
-          "stops": [
-            [
-              8,
-              8
-            ],
-            [
-              14,
-              13
-            ]
-          ]
-        },
+        "icon-image": "park",
+        "text-font": [
+          "Roboto Condensed Italic"
+        ],
         "visibility": "visible",
-        "symbol-spacing": 250,
-        "text-padding": 5
+        "text-padding": 1
       },
       "paint": {
-        "text-color": "#384646",
-        "text-halo-color": "rgba(255,255,255,1)",
-        "icon-halo-width": 0,
-        "icon-halo-color": "rgba(0, 0, 0, 0)",
-        "text-halo-width": 2
-      }
-    },
-    {
-      "id": "label-town",
-      "type": "symbol",
-      "source": "tilezen",
-      "source-layer": "places",
-      "minzoom": 7,
-      "maxzoom": 13,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "town",
-          "little_town",
-          "railway_station"
-        ]
-      ],
-      "layout": {
-        "text-field": "{name}",
-        "text-font": [
-          "Roboto Medium"
-        ],
-        "text-max-width": 10,
-        "text-letter-spacing": 0.1,
-        "text-size": {
-          "stops": [
-            [
-              8,
-              12
-            ],
-            [
-              12,
-              13
-            ]
-          ]
-        },
-        "visibility": "visible"
-      },
-      "paint": {
-        "text-color": "#384646",
-        "text-halo-color": "rgba(255,255,255,0.5)",
-        "text-halo-width": 2,
-        "icon-halo-width": 0,
-        "icon-halo-color": "rgba(0, 0, 0, 0)"
-      }
-    },
-    {
-      "id": "label-city",
-      "type": "symbol",
-      "source": "tilezen",
-      "source-layer": "places",
-      "minzoom": 7,
-      "maxzoom": 14,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "city"
-        ]
-      ],
-      "layout": {
-        "text-field": "{name}",
-        "text-font": [
-          "Roboto Medium"
-        ],
-        "text-max-width": 10,
-        "text-letter-spacing": 0.1,
-        "text-size": 18
-      },
-      "paint": {
-        "text-color": "#384646",
-        "text-halo-color": "rgba(255,255,255,0.5)",
-        "icon-halo-width": 2,
-        "icon-halo-color": "rgba(255, 255, 255, 1)"
+        "text-color": "rgba(26, 92, 0, 1)",
+        "text-halo-width": 1,
+        "text-halo-color": "rgba(255, 255, 255, 0.7)"
       }
     },
     {
@@ -1846,7 +1752,7 @@
       "type": "symbol",
       "source": "tilezen",
       "source-layer": "roads",
-      "minzoom": 8,
+      "minzoom": 7,
       "maxzoom": 11,
       "filter": [
         "all",
@@ -1881,7 +1787,8 @@
         "text-padding": 30,
         "symbol-avoid-edges": false,
         "text-pitch-alignment": "viewport",
-        "icon-rotation-alignment": "viewport"
+        "icon-rotation-alignment": "viewport",
+        "text-ignore-placement": false
       },
       "paint": {
         "text-halo-width": 2,
@@ -1975,11 +1882,135 @@
         "text-allow-overlap": false,
         "text-font": [
           "Roboto Regular"
-        ]
+        ],
+        "visibility": "visible"
       },
       "paint": {
         "text-halo-width": 2,
         "text-halo-color": "rgba(255, 255, 255, 1)"
+      }
+    },
+    {
+      "id": "label-village",
+      "type": "symbol",
+      "source": "tilezen",
+      "source-layer": "places",
+      "minzoom": 10,
+      "maxzoom": 15,
+      "filter": [
+        "any",
+        [
+          "==",
+          "kind",
+          "village"
+        ]
+      ],
+      "layout": {
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Regular"
+        ],
+        "text-max-width": 10,
+        "text-letter-spacing": 0.05,
+        "text-size": {
+          "stops": [
+            [
+              8,
+              8
+            ],
+            [
+              14,
+              13
+            ]
+          ]
+        },
+        "visibility": "visible",
+        "symbol-spacing": 250,
+        "text-padding": 5
+      },
+      "paint": {
+        "text-color": "#384646",
+        "text-halo-color": "rgba(255,255,255,1)",
+        "icon-halo-width": 0,
+        "icon-halo-color": "rgba(0, 0, 0, 0)",
+        "text-halo-width": 2
+      }
+    },
+    {
+      "id": "label-town",
+      "type": "symbol",
+      "source": "tilezen",
+      "source-layer": "places",
+      "minzoom": 7,
+      "maxzoom": 13,
+      "filter": [
+        "all",
+        [
+          "in",
+          "kind",
+          "town",
+          "little_town",
+          "railway_station"
+        ]
+      ],
+      "layout": {
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Medium"
+        ],
+        "text-max-width": 10,
+        "text-letter-spacing": 0.05,
+        "text-size": {
+          "stops": [
+            [
+              8,
+              12
+            ],
+            [
+              12,
+              13
+            ]
+          ]
+        },
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#384646",
+        "text-halo-color": "rgba(255,255,255,0.5)",
+        "text-halo-width": 2,
+        "icon-halo-width": 0,
+        "icon-halo-color": "rgba(0, 0, 0, 0)"
+      }
+    },
+    {
+      "id": "label-city",
+      "type": "symbol",
+      "source": "tilezen",
+      "source-layer": "places",
+      "minzoom": 7,
+      "maxzoom": 11,
+      "filter": [
+        "all",
+        [
+          "in",
+          "kind",
+          "city"
+        ]
+      ],
+      "layout": {
+        "text-field": "{name}",
+        "text-font": [
+          "Roboto Medium"
+        ],
+        "text-max-width": 10,
+        "text-letter-spacing": 0.05,
+        "text-size": 18,
+        "visibility": "visible"
+      },
+      "paint": {
+        "text-color": "#384646",
+        "text-halo-color": "rgba(255,255,255,0.5)",
+        "text-halo-width": 3
       }
     },
     {
@@ -2069,35 +2100,6 @@
         "text-size": 12,
         "text-max-width": 9,
         "text-anchor": "top",
-        "text-font": [
-          "Roboto Condensed Italic"
-        ],
-        "visibility": "visible",
-        "text-padding": 1
-      },
-      "paint": {
-        "text-color": "rgba(26, 92, 0, 1)",
-        "text-halo-width": 1,
-        "text-halo-color": "rgba(255, 255, 255, 0.7)"
-      }
-    },
-    {
-      "id": "label-park",
-      "type": "symbol",
-      "source": "tilezen",
-      "source-layer": "poi",
-      "minzoom": 7,
-      "maxzoom": 11,
-      "layout": {
-        "text-field": "{name}",
-        "text-size": 12,
-        "text-max-width": 9,
-        "text-anchor": "top",
-        "text-offset": [
-          0,
-          0.6
-        ],
-        "icon-image": "park",
         "text-font": [
           "Roboto Condensed Italic"
         ],

--- a/demo/styles/map.json
+++ b/demo/styles/map.json
@@ -1660,7 +1660,6 @@
         "text-font": [
           "Roboto Condensed Italic"
         ],
-        "visibility": "visible",
         "text-padding": 1
       },
       "paint": {
@@ -1787,8 +1786,7 @@
         "text-padding": 30,
         "symbol-avoid-edges": false,
         "text-pitch-alignment": "viewport",
-        "icon-rotation-alignment": "viewport",
-        "text-ignore-placement": false
+        "icon-rotation-alignment": "viewport"
       },
       "paint": {
         "text-halo-width": 2,
@@ -1882,8 +1880,7 @@
         "text-allow-overlap": false,
         "text-font": [
           "Roboto Regular"
-        ],
-        "visibility": "visible"
+        ]
       },
       "paint": {
         "text-halo-width": 2,
@@ -1924,7 +1921,6 @@
             ]
           ]
         },
-        "visibility": "visible",
         "symbol-spacing": 250,
         "text-padding": 5
       },
@@ -1971,8 +1967,7 @@
               13
             ]
           ]
-        },
-        "visibility": "visible"
+        }
       },
       "paint": {
         "text-color": "#384646",
@@ -2004,8 +1999,7 @@
         ],
         "text-max-width": 10,
         "text-letter-spacing": 0.05,
-        "text-size": 18,
-        "visibility": "visible"
+        "text-size": 18
       },
       "paint": {
         "text-color": "#384646",

--- a/queries/landuse/z12.pgsql
+++ b/queries/landuse/z12.pgsql
@@ -28,6 +28,8 @@ SELECT
         THEN 'sand'
       WHEN "natural" = 'scrub'
         THEN 'scrub'
+      WHEN aeroway is not null
+        THEN aeroway
     END
   ) AS kind
 FROM
@@ -36,6 +38,7 @@ WHERE
   way && !bbox! AND
   (
     landuse IN ('forest', 'residential', 'commercial', 'industrial', 'meadow', 'farmland', 'allotments', 'cemetery', 'garages') OR
-   "natural" in ('wetland', 'beach', 'sand', 'scrub')
+   "natural" in ('wetland', 'beach', 'sand', 'scrub') OR
+   aeroway = 'runway'
   ) AND
   way_area >= 100000

--- a/tiles.cfg
+++ b/tiles.cfg
@@ -54,7 +54,8 @@
             "16": "queries/water/z16.pgsql"
           },
           "srid": 3857,
-          "padding": 5
+          "padding": 5,
+          "simplify": 0.4
         }
       }
     },


### PR DESCRIPTION
1. Oro uostų pakilimo takai yra dideli, todėl matomi vienu masteliu anksčiau.
2. Sumažintas tarpas tarp raidžių gyvenviečių pavadinimams.
3. Padidintas didmiesčių pavadinimo rodymo prioritetas ir sumažintas mastelių, kur rodomas didmiesčių pavadinimas diapazonas.
4. Gyvenviečių pavadinimai svarbesni nei nacionalinių/regioninių parkų pavadinimai.
5. Mažesnis vandens objektų suapvalinimas.