### PR TITLE
Craft sluoksnyje pridėti id/type laukai, kad veiktų tiesioginės nuorodos

### DIFF
--- a/queries/craftbeer/z16.pgsql
+++ b/queries/craftbeer/z16.pgsql
@@ -1,4 +1,7 @@
 SELECT
+  id,
+  id AS __id__,
+  __type__,
   way AS __geometry__,
   name,
   (


### PR DESCRIPTION
Pridėti id ir type laukai, kad veiktų standartinis openmap.lt lankytinos vietos bendrinimas.