### PR TITLE
Kelių ir administracinių ribų informacijos perskirstymas

### DIFF
--- a/queries/boundaries/z13.pgsql
+++ b/queries/boundaries/z13.pgsql
@@ -9,6 +9,8 @@ SELECT
         THEN 'region'
       WHEN admin_level = '6'
         THEN 'county'
+      WHEN admin_level = '8'
+        THEN 'locality'
     END
   ) AS kind
 FROM
@@ -16,5 +18,5 @@ FROM
 WHERE
   way && !bbox! AND
   boundary = 'administrative' AND
-  ((admin_level = '2' AND name = 'Lietuva') or admin_level IN ('4', '6')) AND
+  ((admin_level = '2' AND name = 'Lietuva') or admin_level IN ('4', '6', '8')) AND
   name not in ('Latgale', 'Kurzeme', 'Zemgale')

--- a/queries/roads/z2a.pgsql
+++ b/queries/roads/z2a.pgsql
@@ -35,10 +35,9 @@ WHERE
                'residential',
                'pedestrian',
                'track')
-   OR
-   (railway = 'rail' AND service IS NULL)
-   OR
-   aeroway IN ('runway', 'taxiway', 'parking_position')
+   OR (highway = 'service' AND service IS NULL)
+   OR (railway = 'rail' AND service IS NULL)
+   OR aeroway IN ('runway', 'taxiway', 'parking_position')
   )
 GROUP BY kind, name, priority, ref
 ORDER BY priority

--- a/tiles.cfg
+++ b/tiles.cfg
@@ -143,6 +143,9 @@
             "8": "queries/boundaries/z8.pgsql",
             "9": "queries/boundaries/z8.pgsql",
             "10": "queries/boundaries/z10.pgsql"
+            "11": "queries/boundaries/z10.pgsql"
+            "12": "queries/boundaries/z10.pgsql"
+            "13": "queries/boundaries/z13.pgsql"
           },
           "srid": 3857,
           "simplify": 0.5,

--- a/tiles.cfg
+++ b/tiles.cfg
@@ -142,9 +142,9 @@
             "7": "queries/boundaries/z8.pgsql",
             "8": "queries/boundaries/z8.pgsql",
             "9": "queries/boundaries/z8.pgsql",
-            "10": "queries/boundaries/z10.pgsql"
-            "11": "queries/boundaries/z10.pgsql"
-            "12": "queries/boundaries/z10.pgsql"
+            "10": "queries/boundaries/z10.pgsql",
+            "11": "queries/boundaries/z10.pgsql",
+            "12": "queries/boundaries/z10.pgsql",
             "13": "queries/boundaries/z13.pgsql"
           },
           "srid": 3857,


### PR DESCRIPTION
1. Gyvenviečių administracinės ribos (_admin_level=8_) pasirodo tik 13 mastelyje.
2. Svarbesni _service_ (kur _service is null_) pasirodo kartu su _track_, nes kitaip atsiranda kelių tinklo trūkiai.