### PR TITLE
Smulkesniame mastelyje rodyti tik konkrečiai išskirtus service

### DIFF
--- a/queries/roads/z2a.pgsql
+++ b/queries/roads/z2a.pgsql
@@ -35,7 +35,7 @@ WHERE
                'residential',
                'pedestrian',
                'track')
-   OR (highway = 'service' AND service IS NULL)
+   OR (highway = 'service' AND service = 'long_distance')
    OR (railway = 'rail' AND service IS NULL)
    OR aeroway IN ('runway', 'taxiway', 'parking_position')
   )


### PR DESCRIPTION
Per daug yra _service_ kelių (beveik 100000), kad juos būtų praktiška visus suklasifikuoti teisingai. Tuo labiau, naujus _service_ kelius žymėtojai beveik visada žymi be _service_ žymos. Kitavertus jungiamųjų _service_ kelių yra pakankamai nedaug. Taigi geriau juos pažymėti su _service='long_distance'_ ir tada smulkesniame mastelyje tik tokius _service_ ir rodyti.