### PR TITLE
Generalizacija: neautomatinė, paprastinimas, užklausa

### DIFF
--- a/db/update.sh
+++ b/db/update.sh
@@ -36,9 +36,10 @@ fi
 psql -d osm -U postgres < remove_outside_objects.sql
 
 # update way generalisation on saturday
-if [[ $(date +%u) -eq 6 ]] ; then
-  psql -d osm -U postgres < way_generalisation.sql
-fi
+# NOTE: IŠJUNGTA, KOL SERVERIS NETURI PAKANKAMAI ATMINTIES APDOROTI
+#if [[ $(date +%u) -eq 6 ]] ; then
+#  psql -d osm -U postgres < way_generalisation.sql
+#fi
 
 ./update_search.sh
 

--- a/queries/roads/z1a.pgsql
+++ b/queries/roads/z1a.pgsql
@@ -8,13 +8,7 @@ FROM
 (SELECT
   st_linemerge(st_collect(way)) AS __geometry__,
   highway AS kind,
-  CASE WHEN highway = 'motorway' THEN 1
-       WHEN highway = 'trunk' THEN 2
-       WHEN highway = 'primary' THEN 3
-       WHEN highway = 'secondary' THEN 4
-       WHEN highway = 'tertiary' THEN 5
-       ELSE 6
-  END AS priority,
+  6 AS priority,
   ref,
   length(ref) AS ref_length
 FROM

--- a/tiles.cfg
+++ b/tiles.cfg
@@ -28,7 +28,7 @@
           },
           "srid": 3857,
           "padding": 30,
-          "simplify": 0.2
+          "simplify": 0.4
         }
       }
     },


### PR DESCRIPTION
1. Serveris neturi pakankamai atminties, kad supaprastintų Lietuvos geležinkelius. Išjungtas perskaičiavimas, duomenys kol kas bus įkeliami rankiniu būdu.
2. Padidintas kelių sluoksnio supaprastinimas. Galima stipriau paprastinti, nes dvigubi keliai (pvz. automagistralės) jau sujungtos į vieną generalizacijos metu.
3. Supaprastinta kelių užklausa.