### PR TITLE
Laikinas paprastas netvarkingų generalizuotų geometrijų sutvarkymas

### DIFF
--- a/db/gen_building.sql
+++ b/db/gen_building.sql
@@ -35,3 +35,21 @@ update gen_building set way = st_multi(st_buffer(way, 0)) where res = 10;
 -- Aggregation/Simplification
 -------------------------------
 update gen_building set status = 'DONE', way = st_multi(stc_simplify_building(way, 10)) where res = 10;
+
+--------------------------------------------------------------------------
+-- Fix invalid geometries
+-- (This should eventually be done properly in simplification algorithm)
+--------------------------------------------------------------------------
+do $$declare
+c record;
+begin
+  for c in (select id from gen_building where not st_isvalid(way) and res = 10) loop
+    raise notice '=== Invalid geometry for gen_building.id=%', c.id;
+    update gen_building set way = st_makevalid(way) where id = c.id;
+  end loop;
+end$$;
+
+----------------
+-- Update area
+----------------
+update gen_building set way_area = st_area(way) where res = 10;


### PR DESCRIPTION
Pastatų paprastinimo algoritmas kai kuriais atvejais sugeneruoja netinkamas geometrijas (persidengia išoriniai ir vidiniai žiedai):
![paveikslas](https://user-images.githubusercontent.com/969513/39936841-70f44826-5556-11e8-8eb1-54799aa980a7.png)

Laikinai pridangstome juos paprastu _st_makevalid_, vėliau reikės atitinkamai sutvarkyti paprastinimo algoritmą.