### PR TITLE
Sutvarkytas coastline geometrijų sujungimas

### DIFF
--- a/queries/coastline/z11.pgsql
+++ b/queries/coastline/z11.pgsql
@@ -1,5 +1,5 @@
 SELECT
-  gid AS __id__,
+  1 AS __id__,
   st_union(geom) AS __geometry__,
   'coastline' AS kind
 FROM
@@ -7,5 +7,3 @@ FROM
 WHERE
   geom && !bbox! AND
   res = 10
-GROUP BY
-  gid

--- a/queries/coastline/z15.pgsql
+++ b/queries/coastline/z15.pgsql
@@ -1,5 +1,5 @@
 SELECT
-  gid AS __id__,
+  1 AS __id__,
   st_union(geom) AS __geometry__,
   'coastline' AS kind
 FROM
@@ -7,5 +7,3 @@ FROM
 WHERE
   geom && !bbox! AND
   res = 0
-GROUP BY
-  gid

--- a/queries/coastline/z7.pgsql
+++ b/queries/coastline/z7.pgsql
@@ -1,6 +1,6 @@
 SELECT
   1 AS __id__,
-  st_buffer(st_union(geom), 10) AS __geometry__,
+  st_union(geom) AS __geometry__,
   'coastline' AS kind
 FROM
   coastline

--- a/queries/coastline/z7.pgsql
+++ b/queries/coastline/z7.pgsql
@@ -1,11 +1,9 @@
 SELECT
-  gid AS __id__,
-  st_union(geom) AS __geometry__,
+  1 AS __id__,
+  st_buffer(st_union(geom), 10) AS __geometry__,
   'coastline' AS kind
 FROM
   coastline
 WHERE
   geom && !bbox! AND
   res = 600
-GROUP BY
-  gid

--- a/queries/coastline/z9.pgsql
+++ b/queries/coastline/z9.pgsql
@@ -1,5 +1,5 @@
 SELECT
-  gid AS __id__,
+  1 AS __id__,
   st_union(geom) AS __geometry__,
   'coastline' AS kind
 FROM
@@ -7,5 +7,3 @@ FROM
 WHERE
   geom && !bbox! AND
   res = 150
-GROUP BY
-  gid


### PR DESCRIPTION
Su nereikalingu _group by_ geometrijos likdavo atskiros, dėl to paryškinant _coastline_ geometrijos perimetrą gaudavosi artefaktai ties _coastline_ sujungimais.