### PR TITLE
Kelių danga

### DIFF
--- a/config.toml.template
+++ b/config.toml.template
@@ -214,6 +214,7 @@ srid = 3857
   [[providers.layers]]
   name = "address16"
   sql = """%./data/address/z16.pgsql%"""
+  geometry_type = "Point"
 
   [[providers.layers]]
   name = "coastline7"
@@ -222,6 +223,7 @@ srid = 3857
   [[providers.layers]]
   name = "coastline9"
   sql = """%./data/coastline/z9.pgsql%"""
+  geometry_type = "Polygon"
 
   [[providers.layers]]
   name = "coastline11"
@@ -374,7 +376,7 @@ center = [23.871, 55.191, 7.0]
   name = "water"
   provider_layer = "osm.water16"
   min_zoom = 16
-  max_zoom = 16
+  max_zoom = 18
 
   [[maps.layers]]
   name = "landuse"

--- a/data/roads/z2.pgsql
+++ b/data/roads/z2.pgsql
@@ -10,6 +10,9 @@ FROM
 (SELECT
   st_linemerge(st_collect(way)) AS geom,
   highway AS kind,
+  CASE WHEN surface in ('paved', 'asphalt', 'paving_stones') THEN 'paved'
+       ELSE 'unpaved'
+  END AS surface,
   CASE WHEN highway = 'motorway' THEN 1
        WHEN highway = 'trunk' THEN 2
        WHEN highway = 'primary' THEN 3
@@ -35,13 +38,14 @@ WHERE
                'residential',
                'pedestrian')
   )
-GROUP BY kind, name, priority, ref
+GROUP BY kind, surface, name, priority, ref
 
 UNION ALL
 
 SELECT
   way AS geom,
   'rail' AS kind,
+  'paved' AS surface,
   7 AS priority,
   null AS name,
   null AS ref,

--- a/data/roads/z2a.pgsql
+++ b/data/roads/z2a.pgsql
@@ -11,6 +11,9 @@ SELECT
         THEN aeroway
     END
   ) AS kind,
+  CASE WHEN surface in ('paved', 'asphalt', 'paving_stones') THEN 'paved'
+       ELSE 'unpaved'
+  END AS surface,
   CASE WHEN highway = 'motorway' THEN 1
        WHEN highway = 'trunk' THEN 2
        WHEN highway = 'primary' THEN 3
@@ -40,5 +43,5 @@ WHERE
    OR (railway = 'rail' AND service IS NULL)
    OR aeroway IN ('runway', 'taxiway', 'parking_position')
   )
-GROUP BY kind, name, priority, ref
+GROUP BY kind, surface, name, priority, ref
 ORDER BY priority

--- a/data/roads/z3.pgsql
+++ b/data/roads/z3.pgsql
@@ -11,6 +11,9 @@ SELECT
         THEN aeroway
     END
   ) AS kind,
+  CASE WHEN surface in ('paved', 'asphalt', 'paving_stones') THEN 'paved'
+       ELSE 'unpaved'
+  END AS surface,
   CASE WHEN highway = 'motorway' THEN 1
        WHEN highway = 'trunk' THEN 2
        WHEN highway = 'primary' THEN 3
@@ -62,5 +65,5 @@ WHERE
    railway = 'rail' OR
    aeroway IN ('runway', 'taxiway', 'parking_position')
   )
-GROUP BY kind, name, priority, ref, is_tunnel, is_bridge, oneway
+GROUP BY kind, surface, name, priority, ref, is_tunnel, is_bridge, oneway
 ORDER BY priority

--- a/demo/styles/topo.json
+++ b/demo/styles/topo.json
@@ -9,21 +9,21 @@
       "type": "vector",
       "attribution": "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap contributors</a>",
       "tiles": [
-        "https://openmap.lt/all/{z}/{x}/{y}.pbf"
+        "https://openmap.lt/maps/all/{z}/{x}/{y}.pbf"
       ]
     },
     "topo": {
       "type": "vector",
       "attribution": "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap contributors</a>",
       "tiles": [
-        "https://openmap.lt/topo/{z}/{x}/{y}.pbf"
+        "https://openmap.lt/maps/topo/{z}/{x}/{y}.pbf"
       ]
     },
     "detail": {
       "type": "vector",
       "attribution": "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap contributors</a>",
       "tiles": [
-        "https://openmap.lt/detail/{z}/{x}/{y}.pbf"
+        "https://openmap.lt/maps/detail/{z}/{x}/{y}.pbf"
       ]
     }
   },
@@ -830,7 +830,7 @@
       }
     },
     {
-      "id": "casing-tertiary",
+      "id": "casing-tertiary-unpaved",
       "type": "line",
       "source": "tilezen",
       "source-layer": "roads",
@@ -841,6 +841,11 @@
           "kind",
           "tertiary",
           "tertiary_link"
+        ],
+        [
+          "==",
+          "surface",
+          "unpaved"
         ]
       ],
       "layout": {
@@ -849,6 +854,47 @@
       },
       "paint": {
         "line-color": "rgba(100, 100, 0, 1)",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [
+              5,
+              2
+            ],
+            [
+              20,
+              25
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "casing-tertiary-paved",
+      "type": "line",
+      "source": "tilezen",
+      "source-layer": "roads",
+      "filter": [
+        "all",
+        [
+          "in",
+          "kind",
+          "tertiary",
+          "tertiary_link"
+        ],
+        [
+          "==",
+          "surface",
+          "paved"
+        ]
+      ],
+      "layout": {
+        "line-join": "round",
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#111111",
         "line-width": {
           "base": 1.55,
           "stops": [
@@ -1201,7 +1247,7 @@
       }
     },
     {
-      "id": "road-tertiary",
+      "id": "road-tertiary-paved",
       "type": "line",
       "source": "tilezen",
       "source-layer": "roads",
@@ -1212,11 +1258,58 @@
           "kind",
           "tertiary",
           "tertiary_link"
+        ],
+        [
+          "==",
+          "surface",
+          "paved"
         ]
       ],
       "layout": {
         "line-join": "round",
-        "line-cap": "round"
+        "line-cap": "round",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "#d7b7ad",
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [
+              5,
+              1
+            ],
+            [
+              20,
+              20
+            ]
+          ]
+        }
+      }
+    },
+    {
+      "id": "road-tertiary-unpaved",
+      "type": "line",
+      "source": "tilezen",
+      "source-layer": "roads",
+      "filter": [
+        "all",
+        [
+          "in",
+          "kind",
+          "tertiary",
+          "tertiary_link"
+        ],
+        [
+          "==",
+          "surface",
+          "unpaved"
+        ]
+      ],
+      "layout": {
+        "line-join": "round",
+        "line-cap": "round",
+        "visibility": "visible"
       },
       "paint": {
         "line-color": "rgba(230, 220, 0, 1)",
@@ -1987,7 +2080,9 @@
         "text-allow-overlap": false,
         "text-font": [
           "Playfair Regular"
-        ]
+        ],
+        "visibility": "visible",
+        "text-letter-spacing": 0.05
       },
       "paint": {
         "text-halo-width": 1.5,

--- a/demo/styles/topo.json
+++ b/demo/styles/topo.json
@@ -7,24 +7,15 @@
   "sources": {
     "tilezen": {
       "type": "vector",
-      "attribution": "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap contributors</a>",
-      "tiles": [
-        "https://openmap.lt/maps/all/{z}/{x}/{y}.pbf"
-      ]
+      "url": "https://openmap.lt/capabilities/all.json"
     },
     "topo": {
       "type": "vector",
-      "attribution": "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap contributors</a>",
-      "tiles": [
-        "https://openmap.lt/maps/topo/{z}/{x}/{y}.pbf"
-      ]
+      "url": "https://openmap.lt/capabilities/topo.json"
     },
     "detail": {
       "type": "vector",
-      "attribution": "© <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap contributors</a>",
-      "tiles": [
-        "https://openmap.lt/maps/detail/{z}/{x}/{y}.pbf"
-      ]
+      "url": "https://openmap.lt/capabilities/detail.json"
     }
   },
   "sprite": "https://openmap.lt/sprites/topo",


### PR DESCRIPTION
1. Kelių (_roads_) sluoksnyje pridėta kelių danga (galimos reikšmės „paved“ ir „unpaved“).
2. Topografiniame žemėlapyje _tertiary_ keliai, kurie yra su kieta danga rodomi taip pat, kaip _secondary_ keliai (tai labiau atitinka Lietuvos topografinio žemėlapio taisykles ir vizualiai kietos dangos keliai vaizduojami rusvai, o ne gelsvai).
3. Tegolos konfigūraciniame faile nurodyta adresų sluoksnio geometrija (_Point_), dėl ko stipriai pagreitėja Tegolos paleidimas.
4. Vandens sluoksnis generuojamas iki 18, o ne iki 16 mastelio (pataisyta klaida, kad vanduo nebesimato > 16 mastelio).