### PR TITLE
Dviračių nuomos punktai ir autobusų stotys

### DIFF
--- a/data/poi/z16.pgsql
+++ b/data/poi/z16.pgsql
@@ -18,6 +18,8 @@ SELECT
       THEN 'bicycle_parking'
     WHEN amenity = 'bicycle_rental'
       THEN 'bicycle_rental'
+    WHEN amenity = 'bus_station'
+      THEN 'bus'
     WHEN amenity = 'cafe'
       THEN 'cafe'
     WHEN amenity = 'car_wash'
@@ -160,6 +162,7 @@ WHERE
                 'bar',
                 'bicycle_parking',
                 'bicycle_rental',
+                'bus_station',
                 'cafe',
                 'car_wash',
                 'cinema',

--- a/db/table_poi.sql
+++ b/db/table_poi.sql
@@ -1,3 +1,4 @@
+drop materialized view if exists poi;
 create materialized view poi (
   id
  ,__type__
@@ -104,6 +105,46 @@ create materialized view poi (
         ,real_ale
         ,st_centroid(way)
     from planet_osm_polygon
+   where amenity is not null
+      or shop is not null
+      or real_ale is not null
+      or tourism is not null
+      or historic is not null
+      or office is not null
+  union
+  select
+        ABS(osm_id)
+        ,'w'
+        ,name
+        ,amenity
+        ,man_made
+        ,"tower:type"
+        ,tourism
+        ,null --"attraction:type"
+        ,access
+        ,historic
+        ,site_type
+        ,shop
+        ,information
+        ,office
+        ,official_name
+        ,alt_name
+        ,opening_hours
+        ,website
+        ,image
+        ,"ref:lt:kpd"
+        ,height
+        ,wikipedia
+        ,fee
+        ,email
+        ,phone
+        ,"addr:city"
+        ,"addr:street"
+        ,"addr:housenumber"
+        ,"addr:postcode"
+        ,real_ale
+        ,st_centroid(way)
+    from planet_osm_line
    where amenity is not null
       or shop is not null
       or real_ale is not null

--- a/demo/sprites/openmaplt.json
+++ b/demo/sprites/openmaplt.json
@@ -104,7 +104,7 @@
     "x": 53,
     "y": 80
   },
-  "bicycle-share": {
+  "bicycle_rental": {
     "height": 19,
     "pixelRatio": 1,
     "width": 19,

--- a/demo/sprites/openmaplt@2x.json
+++ b/demo/sprites/openmaplt@2x.json
@@ -104,7 +104,7 @@
     "x": 53,
     "y": 80
   },
-  "bicycle-share": {
+  "bicycle_rental": {
     "height": 19,
     "pixelRatio": 1,
     "width": 19,


### PR DESCRIPTION
1. Pataisytos dviračių nuomos punktų piktogramos (https://github.com/openmaplt/vector-map/issues/186).
2. Pridėtos autobusų stotys (https://github.com/openmaplt/vector-map/issues/190).
3. Prie lankytinų vietų pridėti ir linijiniai objektai (https://github.com/openmaplt/vector-map/issues/187)