### PR TITLE
Geležinkelio, oro ir vandens transporto taškai

### DIFF
--- a/data/poi/z16.pgsql
+++ b/data/poi/z16.pgsql
@@ -107,6 +107,17 @@ SELECT
     WHEN tourism = 'attraction'
       THEN 'attraction'
 
+    WHEN railway = 'station'
+      THEN 'rail'
+    WHEN aeroway = 'terminal'
+      THEN 'airport'
+    WHEN aeroway = 'helipad'
+      THEN 'heliport'
+    WHEN aeroway = 'aerodrome'
+      THEN 'airfield'
+    WHEN amenity = 'ferry_terminal'
+      THEN 'ferry'
+
     WHEN shop = 'alcohol'
       THEN 'alcohol-shop'
     WHEN shop = 'car_repair'
@@ -173,6 +184,7 @@ WHERE
                 'dentist',
                 'doctors',
                 'fast_food',
+                'ferry_terminal',
                 'fire_station',
                 'fuel',
                 'hospital',
@@ -225,7 +237,9 @@ WHERE
               'government',
               'notary',
               'lawyer'
-    )
+    ) OR
+    railway = 'station' OR
+    aeroway in ('terminal', 'helipad', 'aerodrome')
   )
 ORDER BY
   CASE WHEN tourism = 'attraction' then 1
@@ -233,7 +247,8 @@ ORDER BY
        WHEN tourism in ('camp_site', 'caravan_site') then 3
        WHEN tourism is not null then 4
        WHEN historic is not null then 5
-       WHEN amenity is not null then 6
-       WHEN shop is not null then 7
-       ELSE 8
+       WHEN railway is not null or aeroway is not null then 6
+       WHEN amenity is not null then 7
+       WHEN shop is not null then 8
+       ELSE 9
   END

--- a/db/table_poi.sql
+++ b/db/table_poi.sql
@@ -30,6 +30,8 @@ create materialized view poi (
  ,"addr:housenumber"
  ,"addr:postcode"
  ,real_ale
+ ,railway
+ ,aeroway
  ,way
 ) as
   select
@@ -63,6 +65,8 @@ create materialized view poi (
         ,"addr:housenumber"
         ,"addr:postcode"
         ,real_ale
+        ,railway
+        ,aeroway
         ,way
     from planet_osm_point
    where amenity is not null
@@ -71,6 +75,8 @@ create materialized view poi (
       or tourism is not null
       or historic is not null
       or office is not null
+      or railway = 'station'
+      or aeroway in ('terminal', 'helipad', 'aerodrome')
   union
   select
         ABS(osm_id)
@@ -103,6 +109,8 @@ create materialized view poi (
         ,"addr:housenumber"
         ,"addr:postcode"
         ,real_ale
+        ,railway
+        ,aeroway
         ,st_centroid(way)
     from planet_osm_polygon
    where amenity is not null
@@ -111,6 +119,8 @@ create materialized view poi (
       or tourism is not null
       or historic is not null
       or office is not null
+      or railway = 'station'
+      or aeroway in ('terminal', 'helipad', 'aerodrome')
   union
   select
         ABS(osm_id)
@@ -143,6 +153,8 @@ create materialized view poi (
         ,"addr:housenumber"
         ,"addr:postcode"
         ,real_ale
+        ,null
+        ,null
         ,st_centroid(way)
     from planet_osm_line
    where amenity is not null


### PR DESCRIPTION
Pridėtos lankytinos vietos nuo 16 mastelio:
1. Geležinkelio stotys (_railway=station_)
2. Oro uostų terminalai (_aeroway=terminal_)
3. Aerodromai (_aeroway=aerodrome_)
4. Sraigtasparnių aikštelės (_aeroway=helipad_)
5. Keltų terminalai (_amenity=ferry_terminal_)