### PR TITLE
Pataisytas gyvenviečių id lauko pavadinimas

### DIFF
--- a/data/places/z10.pgsql
+++ b/data/places/z10.pgsql
@@ -1,5 +1,5 @@
 SELECT
-  place.gid AS gis,
+  place.gid AS gid,
   ST_AsBinary(place.geom) AS geom,
   place.name,
   place.kind

--- a/data/water/z10.pgsql
+++ b/data/water/z10.pgsql
@@ -36,7 +36,7 @@ WHERE
 UNION ALL
 
 SELECT
-  row_number() over() AS gid,
+  (row_number() over()) + 1000 AS gid,
   st_asbinary(st_union(way)) AS geom,
   'water' AS kind,
   null AS name


### PR DESCRIPTION
Dėl šito Tegola 10 mastelyje įtraukdavo į kaladėlę tik vieną (pirmą) gyvenvietę.
Ir 10 vandens mastelyje rodė tik kai kuriuos vandens plotus (kurių sekos numeris nesutapo su _riverbank_ sekos numeriu).