### PR TITLE
Užtvankų papildymas: embankment

### DIFF
--- a/data/detail_line/z13.pgsql
+++ b/data/detail_line/z13.pgsql
@@ -6,4 +6,4 @@ FROM
   details_line
 WHERE
   geom && !BBOX! AND
-  kind in ('cutline', 'dam')
+  kind in ('cutline', 'dam', 'dam_highway')

--- a/db/osm2pgsql.style
+++ b/db/osm2pgsql.style
@@ -169,3 +169,4 @@ way        footway      text         linear
 node,way   voltage      text         linear
 node,way   z_order      int4         linear # This is calculated during import
 way        way_area     real                # This is calculated during import
+way        embankment:type text

--- a/db/table_details_line.sql
+++ b/db/table_details_line.sql
@@ -9,14 +9,16 @@ SELECT
   osm_id AS gid,
   ST_AsBinary(way),
   way,
-  coalesce(man_made, "natural",
-    case when waterway = 'dam' then 'dam'
-         when waterway = 'weir' then 'dam'
-    end
-  ) AS kind
+  case when man_made = 'cutline' then 'cutline'
+       when "natural" = 'cliff' then 'cliff'
+       when waterway in ('dam', 'weir') then 'dam'
+       when highway is not null and man_made = 'embankment' then 'dam_highway'
+       when man_made = 'embankment' then 'dam'
+  end AS kind
 FROM
   planet_osm_line
 WHERE
   (man_made = 'cutline' OR
    "natural" = 'cliff' OR
-   waterway in ('dam', 'weir'));
+   waterway in ('dam', 'weir') OR
+   (man_made = 'embankment' and "embankment:type" = 'dam'));

--- a/demo/styles/topo.json
+++ b/demo/styles/topo.json
@@ -609,11 +609,94 @@
       }
     },
     {
-      "id": "detail-dam-teeth",
+      "id": "dam-teeth-highway",
       "type": "line",
       "source": "detail",
       "source-layer": "detail_line",
-      "minzoom": 15,
+      "minzoom": 13,
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        [
+          "==",
+          "kind",
+          "dam_highway"
+        ]
+      ],
+      "paint": {
+        "line-width": {
+          "stops": [
+            [
+              13,
+              3
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              18,
+              15
+            ]
+          ]
+        },
+        "line-offset": 3,
+        "line-opacity": 1,
+        "line-dasharray": {
+          "stops": [
+            [
+              13,
+              [
+                0.5,
+                0.9
+              ]
+            ],
+            [
+              14,
+              [
+                0.4,
+                0.8
+              ]
+            ],
+            [
+              15,
+              [
+                0.3,
+                0.7
+              ]
+            ],
+            [
+              16,
+              [
+                0.25,
+                0.5
+              ]
+            ],
+            [
+              17,
+              [
+                0.2,
+                0.4
+              ]
+            ],
+            [
+              18,
+              [
+                0.2,
+                0.3
+              ]
+            ]
+          ]
+        },
+        "line-color": "#110f0d"
+      }
+    },
+    {
+      "id": "dam-teeth",
+      "type": "line",
+      "source": "detail",
+      "source-layer": "detail_line",
+      "minzoom": 13,
       "maxzoom": 24,
       "filter": [
         "all",
@@ -625,7 +708,7 @@
       ],
       "paint": {
         "line-width": 4,
-        "line-offset": -3,
+        "line-offset": 3,
         "line-opacity": 1,
         "line-dasharray": [
           0.4,
@@ -635,7 +718,7 @@
       }
     },
     {
-      "id": "detail-dam",
+      "id": "dam-main",
       "type": "line",
       "source": "detail",
       "source-layer": "detail_line",


### PR DESCRIPTION
Keliai (_highway=*_) su _man_made=embankment_ ir _embankment:type=dam_ priskaičiuojami prie užtvankų:
![paveikslas](https://user-images.githubusercontent.com/969513/50534868-d4135400-0b4b-11e9-8b70-d74d418c413d.png)

Likusios žinomos problemos:
1. Smulkiuose masteliuose geometrija gali būti trūki, kai šokinėja nuo kelio iki užtvankos įrenginių.
2. Užtvankos simboliai (dantukai), braižomi ant kelių, braižomi pagal vienas taisykles, o keliai gali būti skirtingų klasifikacijų (residential-trunk), todėl jų pločiai gali būti skirtingi. Taigi dabartiniame variante platesniems keliams dantukai išlenda mažesni, nei siauresniems keliams. Tai ypač matosi stambiausiuose masteliuose.