### PR TITLE
Retail žemėnauda irgi komercinė

### DIFF
--- a/data/landuse/z12.pgsql
+++ b/data/landuse/z12.pgsql
@@ -5,6 +5,8 @@ SELECT
     CASE
       WHEN landuse = 'meadow' or "natural" = 'heath'
         THEN 'meadow'
+      WHEN landuse = 'retail'
+        THEN 'commercial'
       WHEN landuse is not null
         THEN landuse
       WHEN "natural" = 'wetland' AND "wetland" = 'marsh'
@@ -26,7 +28,7 @@ FROM
 WHERE
   way && !BBOX! AND
   (
-    landuse IN ('residential', 'commercial', 'industrial', 'meadow', 'farmland', 'allotments', 'cemetery', 'garages', 'orchard', 'farmyard') OR
+    landuse IN ('residential', 'commercial', 'industrial', 'meadow', 'farmland', 'allotments', 'cemetery', 'garages', 'orchard', 'farmyard', 'retail') OR
    "natural" in ('wetland', 'beach', 'sand', 'scrub', 'heath') OR
    aeroway = 'runway'
   ) AND

--- a/data/landuse/z13.pgsql
+++ b/data/landuse/z13.pgsql
@@ -5,6 +5,8 @@ SELECT
     CASE
       WHEN landuse = 'meadow' or "natural" = 'heath'
         THEN 'meadow'
+      WHEN landuse = 'retail'
+        THEN 'commercial'
       WHEN landuse is not null
         THEN landuse
       WHEN "natural" = 'wetland' AND "wetland" = 'marsh'
@@ -26,7 +28,7 @@ FROM
 WHERE
   way && !BBOX! AND
   (
-    landuse in ('residential', 'commercial', 'industrial', 'meadow', 'farmland', 'allotments', 'cemetery', 'garages', 'orchard', 'farmyard')
+    landuse in ('residential', 'commercial', 'industrial', 'meadow', 'farmland', 'allotments', 'cemetery', 'garages', 'orchard', 'farmyard', 'retail')
     OR "natural" in ('wetland', 'sand', 'beach', 'scrub', 'heath')
     OR aeroway in ('runway')
   ) AND

--- a/data/landuse/z14.pgsql
+++ b/data/landuse/z14.pgsql
@@ -5,6 +5,8 @@ SELECT
     CASE
       WHEN landuse = 'meadow' or "natural" = 'heath'
         THEN 'meadow'
+      WHEN landuse = 'retail'
+        THEN 'commercial'
       WHEN landuse is not null
         THEN landuse
       WHEN "natural" = 'wetland' AND "wetland" = 'marsh'
@@ -26,7 +28,7 @@ FROM
 WHERE
   way && !BBOX! AND
   (
-    landuse in ('residential', 'commercial', 'industrial', 'meadow', 'farmland', 'allotments', 'cemetery', 'garages', 'orchard', 'farmyard')
+    landuse in ('residential', 'commercial', 'industrial', 'meadow', 'farmland', 'allotments', 'cemetery', 'garages', 'orchard', 'farmyard', 'retail')
     OR "natural" in ('wetland', 'sand', 'beach', 'scrub', 'heath')
     OR aeroway in ('apron', 'runway')
   ) AND

--- a/data/landuse/z15.pgsql
+++ b/data/landuse/z15.pgsql
@@ -5,6 +5,8 @@ SELECT
     CASE
       WHEN landuse = 'meadow' or "natural" = 'heath'
         THEN 'meadow'
+      WHEN landuse = 'retail'
+        THEN 'commercial'
       WHEN landuse is not null
         THEN landuse
       WHEN "natural" = 'wetland' AND "wetland" = 'marsh'
@@ -26,7 +28,7 @@ FROM
 WHERE
   way && !BBOX! AND
   (
-    landuse in ('forest', 'residential', 'commercial', 'industrial', 'meadow', 'farmland', 'allotments', 'cemetery', 'garages', 'orchard', 'farmyard')
+    landuse in ('forest', 'residential', 'commercial', 'industrial', 'meadow', 'farmland', 'allotments', 'cemetery', 'garages', 'orchard', 'farmyard', 'retail')
     OR "natural" in ('wetland', 'sand', 'beach', 'scrub', 'heath')
     OR aeroway in ('apron', 'runway')
   ) AND

--- a/data/landuse/z16.pgsql
+++ b/data/landuse/z16.pgsql
@@ -5,6 +5,8 @@ SELECT
     CASE
       WHEN landuse = 'meadow' or "natural" = 'heath'
         THEN 'meadow'
+      WHEN landuse = 'retail'
+        THEN 'commercial'
       WHEN landuse is not null
         THEN landuse
       WHEN "natural" = 'wetland' AND "wetland" = 'marsh'
@@ -28,7 +30,7 @@ FROM
 WHERE
   way && !BBOX! AND
   (
-    landuse in ('forest', 'residential', 'commercial', 'industrial', 'meadow', 'farmland', 'allotments', 'cemetery', 'garages', 'orchard', 'farmyard')
+    landuse in ('forest', 'residential', 'commercial', 'industrial', 'meadow', 'farmland', 'allotments', 'cemetery', 'garages', 'orchard', 'farmyard', 'retail')
     OR "natural" in ('wetland', 'sand', 'beach', 'scrub', 'heath')
     OR leisure = 'park'
     OR aeroway in ('apron', 'runway')


### PR DESCRIPTION
Pridėti _landuse='retail'_ į vektorines kaladėlės kaip _landuse='commercial'_ (nes tai iš principo tas pats ir kol kas negaliu sugalvoti, kokiam žemėlapyje būtų įdomu rodyti skirtumą tarp _commercial_ ir _retail_).