### PR TITLE
Vandens telkinių etikečių automatinis perskaičiavimas

### DIFF
--- a/db/func/stc_process_centerlines.sql
+++ b/db/func/stc_process_centerlines.sql
@@ -32,7 +32,7 @@ begin
                   ,planet_osm_polygon p
              where p.osm_id = r.osm_id
                and (r.dirty = 'Y' or
-                    now() - r.last_update > interval '1 month'
+                    now() - r.last_update > interval '3 months'
                    )
              order by st_area(p.way) desc
              limit p_limit) loop

--- a/db/osm2pgsql.style
+++ b/db/osm2pgsql.style
@@ -169,4 +169,5 @@ way        footway      text         linear
 node,way   voltage      text         linear
 node,way   z_order      int4         linear # This is calculated during import
 way        way_area     real                # This is calculated during import
+node,way   osm_timestamp timestamptz(0)
 way        embankment:type text

--- a/db/tables/table_car_labels.sql
+++ b/db/tables/table_car_labels.sql
@@ -1,3 +1,4 @@
+create sequence car_labels_seq;
 drop table if exists car_labels;
 create table car_labels(
 id bigint,

--- a/db/tables/table_car_polygon.sql
+++ b/db/tables/table_car_polygon.sql
@@ -1,0 +1,9 @@
+drop table if exists car_polygon;
+create unlogged table car_polygon (
+ id  bigint
+,x   integer
+,y   integer
+,s   text
+,w   integer
+,way geometry);
+create index car_polygon_xy on car_polygon(x, y);

--- a/db/update.sh
+++ b/db/update.sh
@@ -33,7 +33,7 @@ fi
 
 #apply diff
 rm dirty_tiles
-./osm2pgsql --username postgres --database osm --style ./osm2pgsql.style --multi-geometry --number-processes 4 --slim --cache 100 --proj 3857 --expire-tiles 7-18 --append change.osc > /dev/null
+./osm2pgsql --username postgres --database osm --style ./osm2pgsql.style -x --multi-geometry --number-processes 4 --slim --cache 100 --proj 3857 --expire-tiles 7-18 --append change.osc > /dev/null
 
 if [ $? -ne 0 ]; then
 	exit
@@ -46,7 +46,7 @@ psql -d osm -U postgres < remove_outside_objects.sql
 cat dirty_tiles >> dirty_tiles_weekly
 
 # update generalisation on Saturday
-if [[ $(date +%u) -eq 6 ]] ; then
+if [[ $(date +%u) -eq 56 ]] ; then
 # NOTE: IŠJUNGTA, KOL SERVERIS NETURI PAKANKAMAI ATMINTIES APDOROTI
 #  psql -d osm -U postgres < way_generalisation.sql
   echo "water generalisation" `date`
@@ -90,8 +90,10 @@ if [ -s dirty_tiles ]; then
     grep -E "^(10|11|12|13|14)" dirty_tiles > generate_bicycle_$DIRTY_FILE
     grep -E "^(10|11|12|13|14)" dirty_tiles > generate_craftbeer_$DIRTY_FILE
 
-    echo "Refreshing poi materialized view " `date`
+    echo "Refreshing materialized views " `date`
     psql -d osm -U postgres < update_mv.sql
+    echo "Refreshing waterbody labels " `date`
+    psql -d osm -U postgres < update_water_labels.sql
 
     echo "OpenMap.lt delete expired tiles large scale tiles in layer 'all' " `date`
     ../tegola cache purge --config $TEGOLA_CONFIG_FILE --map="all" tile-list delete_openmap_$DIRTY_FILE

--- a/db/update.sh
+++ b/db/update.sh
@@ -46,7 +46,7 @@ psql -d osm -U postgres < remove_outside_objects.sql
 cat dirty_tiles >> dirty_tiles_weekly
 
 # update generalisation on Saturday
-if [[ $(date +%u) -eq 56 ]] ; then
+if [[ $(date +%u) -eq 6 ]] ; then
 # NOTE: IŠJUNGTA, KOL SERVERIS NETURI PAKANKAMAI ATMINTIES APDOROTI
 #  psql -d osm -U postgres < way_generalisation.sql
   echo "water generalisation" `date`

--- a/db/update_water_labels.sql
+++ b/db/update_water_labels.sql
@@ -1,0 +1,18 @@
+delete from car_requests where osm_id not in (select osm_id
+                                               from planet_osm_polygon
+                                              where name is not null
+                                                and ("natural" in ('water', 'bay') or landuse = 'reservoir'));
+insert into car_requests (id, osm_id, type, dirty, last_update)
+  select nextval('car_request_seq')
+        ,osm_id
+        ,'L'
+        ,'Y'
+        ,null
+    from planet_osm_polygon
+   where ("natural" in ('water', 'bay') or landuse = 'reservoir')
+     and name is not null
+     and osm_id not in (select osm_id from car_requests);
+update car_requests r
+   set dirty = 'Y'
+ where exists (select 1 from planet_osm_polygon p where p.osm_id = r.osm_id and p.osm_timestamp > r.last_update - interval '1 hour');
+select stc_process_centerlines();


### PR DESCRIPTION
Po kiekvieno db atnaujinimo perskaičiuoti pasikeitusių vandens telkinių etiketes (ir 3 mėnesius po paskutinio pasikeitimo, nes kai kuriais atvejais _osm_timestamp_ neatsinaujina, nors geometrija ir pasikeitė).