### PR TITLE
Pridėtas fonas miško/lauko keliukams

### DIFF
--- a/demo/styles/topo.json
+++ b/demo/styles/topo.json
@@ -1729,6 +1729,42 @@
       }
     },
     {
+      "id": "road-track-bkg",
+      "type": "line",
+      "source": "tilezen",
+      "source-layer": "roads",
+      "minzoom": 12,
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        [
+          "in",
+          "kind",
+          "track"
+        ]
+      ],
+      "layout": {
+        "line-join": "round",
+        "line-cap": "round"
+      },
+      "paint": {
+        "line-color": "rgba(255, 255, 255, 0.4)",
+        "line-width": {
+          "base": 1.8,
+          "stops": [
+            [
+              10,
+              3
+            ],
+            [
+              20,
+              60
+            ]
+          ]
+        }
+      }
+    },
+    {
       "id": "road-track",
       "type": "line",
       "source": "tilezen",
@@ -1754,7 +1790,7 @@
           "stops": [
             [
               10,
-              0.15
+              0.3
             ],
             [
               20,
@@ -2495,9 +2531,7 @@
         "text-allow-overlap": false,
         "text-font": [
           "Roboto Condensed Italic"
-        ],
-        "text-letter-spacing": 0.1,
-        "text-max-angle": 60
+        ]
       },
       "paint": {
         "text-halo-width": 2,

--- a/demo/styles/topo.json
+++ b/demo/styles/topo.json
@@ -2531,7 +2531,9 @@
         "text-allow-overlap": false,
         "text-font": [
           "Roboto Condensed Italic"
-        ]
+        ],
+        "text-letter-spacing": 0.1,
+        "text-max-angle": 60
       },
       "paint": {
         "text-halo-width": 2,


### PR DESCRIPTION
Taip išryškinami keliukai, jie labiau skiriasi nuo proskynų.
Taipogi išskyrimas imituoja realybę - aplink keliuką yra iškirsti ar bent retesni medžiai.