### PR TITLE
Nedideli skriptų pataisymai

### DIFF
--- a/db/update.sh
+++ b/db/update.sh
@@ -92,8 +92,8 @@ if [ -s dirty_tiles ]; then
 
     for ZOOM in $(seq 15 -1 7); do
         echo "OpenMap.lt regenerate expired $ZOOM " `date`
-        grep -E "^$ZOOM/" dirty_tiles > generate_openmap_$ZOOM_$DIRTY_FILE
-        $TEGOLA_SEED --map="all" tile-list generate_openmap_$ZOOM_$DIRTY_FILE > /dev/null
+        grep -E "^$ZOOM/" dirty_tiles > generate_openmap_${ZOOM}_$DIRTY_FILE
+        $TEGOLA_SEED --map="all" tile-list generate_openmap_${ZOOM}_$DIRTY_FILE > /dev/null
     done
     rm generate_openmap_*_$DIRTY_FILE
 

--- a/db/update_mv.sql
+++ b/db/update_mv.sql
@@ -1,4 +1,5 @@
 refresh materialized view poi;
 refresh materialized view poi_topo;
+refresh materialized view poi_river;
 refresh materialized view details_line;
 refresh materialized view details_poly;


### PR DESCRIPTION
1. DB atnaujinimo skriptas palikdavo po atnaujinimo paskutinio mastelio kaladėlių sąrašo failą.
2. Atnaujinti ir naujai sukurtą upių materializuotą rodinį.