### PR TITLE
Upių išskirstymas į normalias ir virtualias ir update pagerinimas

### DIFF
--- a/data/water/z10.pgsql
+++ b/data/water/z10.pgsql
@@ -11,13 +11,13 @@ SELECT
         THEN 'river'
     END
   ) AS kind,
-  coalesce("name:lt", name) AS name
+  coalesce("name:lt", name) AS name,
+  case when "waterway:speed" is null then 'N' else 'Y' end as virtual
 FROM
   planet_osm_line
 WHERE
   way && !BBOX! AND
-  waterway IN ('dock', 'canal', 'river') AND
-  "waterway:speed" is null
+  waterway IN ('dock', 'canal', 'river')
 
 UNION ALL
 

--- a/data/water/z11.pgsql
+++ b/data/water/z11.pgsql
@@ -13,13 +13,13 @@ SELECT
         THEN 'stream'
     END
   ) AS kind,
-  coalesce("name:lt", name) AS name
+  coalesce("name:lt", name) AS name,
+  case when "waterway:speed" is null then 'N' else 'Y' end as virtual
 FROM
   planet_osm_line
 WHERE
   way && !BBOX! AND
-  waterway IN ('dock', 'canal', 'river', 'stream') AND
-  "waterway:speed" is null
+  waterway IN ('dock', 'canal', 'river', 'stream')
 
 UNION ALL
 

--- a/data/water/z12.pgsql
+++ b/data/water/z12.pgsql
@@ -13,13 +13,13 @@ SELECT
         THEN 'stream'
     END
   ) AS kind,
-  coalesce("name:lt", name) AS name
+  coalesce("name:lt", name) AS name,
+  case when "waterway:speed" is null then 'N' else 'Y' end as virtual
 FROM
   planet_osm_line
 WHERE
   way && !BBOX! AND
-  waterway IN ('dock', 'canal', 'river', 'stream') AND
-  "waterway:speed" is null
+  waterway IN ('dock', 'canal', 'river', 'stream')
 
 UNION ALL
 

--- a/data/water/z13.pgsql
+++ b/data/water/z13.pgsql
@@ -13,13 +13,13 @@ SELECT
         THEN 'stream'
     END
   ) AS kind,
-  coalesce("name:lt", name) AS name
+  coalesce("name:lt", name) AS name,
+  case when "waterway:speed" is null then 'N' else 'Y' end as virtual
 FROM
   planet_osm_line
 WHERE
   way && !BBOX! AND
-  waterway IN ('dock', 'canal', 'river', 'stream') AND
-  "waterway:speed" is null
+  waterway IN ('dock', 'canal', 'river', 'stream')
 
 UNION ALL
 

--- a/data/water/z14.pgsql
+++ b/data/water/z14.pgsql
@@ -2,13 +2,13 @@ SELECT
   osm_id AS gid,
   st_asbinary(way) AS geom,
   waterway AS kind,
-  coalesce("name:lt", name) AS name
+  coalesce("name:lt", name) AS name,
+  case when "waterway:speed" is null then 'N' else 'Y' end as virtual
 FROM
   planet_osm_line
 WHERE
   way && !BBOX! AND
-  waterway IN ('dock', 'canal', 'river', 'stream', 'ditch') AND
-  "waterway:speed" is null
+  waterway IN ('dock', 'canal', 'river', 'stream', 'ditch')
 
 UNION ALL
 

--- a/data/water/z15.pgsql
+++ b/data/water/z15.pgsql
@@ -2,13 +2,13 @@ SELECT
   osm_id AS gid,
   st_asbinary(way) AS geom,
   waterway AS kind,
-  coalesce("name:lt", name) AS name
+  coalesce("name:lt", name) AS name,
+  case when "waterway:speed" is null then 'N' else 'Y' end as virtual
 FROM
   planet_osm_line
 WHERE
   way && !BBOX! AND
-  waterway IN ('dock', 'canal', 'river', 'stream', 'ditch') AND
-  "waterway:speed" is null
+  waterway IN ('dock', 'canal', 'river', 'stream', 'ditch')
 
 UNION ALL
 

--- a/data/water/z16.pgsql
+++ b/data/water/z16.pgsql
@@ -17,13 +17,13 @@ SELECT
         THEN 'drain'
     END
   ) AS kind,
-  coalesce("name:lt", name) AS name
+  coalesce("name:lt", name) AS name,
+  case when "waterway:speed" is null then 'N' else 'Y' end as virtual
 FROM
   planet_osm_line
 WHERE
   way && !BBOX! AND
-  waterway IN ('dock', 'canal', 'river', 'stream', 'ditch', 'drain') AND
-  "waterway:speed" is null
+  waterway IN ('dock', 'canal', 'river', 'stream', 'ditch', 'drain')
 
 UNION ALL
 

--- a/data/water/z8.pgsql
+++ b/data/water/z8.pgsql
@@ -7,13 +7,13 @@ SELECT
         THEN 'river'
     END
   ) AS kind,
-  coalesce("name:lt", name) AS name
+  coalesce("name:lt", name) AS name,
+  case when "waterway:speed" is null then 'N' else 'Y' end as virtual
 FROM
   planet_osm_line
 WHERE
   way && !BBOX! AND
-  waterway = 'river' AND
-  "waterway:speed" is null
+  waterway = 'river'
 
 UNION ALL
 

--- a/data/water/z9.pgsql
+++ b/data/water/z9.pgsql
@@ -11,13 +11,13 @@ SELECT
         THEN 'river'
     END
   ) AS kind,
-  coalesce("name:lt", name) AS name
+  coalesce("name:lt", name) AS name,
+  case when "waterway:speed" is null then 'N' else 'Y' end as virtual
 FROM
   planet_osm_line
 WHERE
   way && !BBOX! AND
-  waterway IN ('dock', 'canal', 'river') AND
-  "waterway:speed" is null
+  waterway IN ('dock', 'canal', 'river')
 
 UNION ALL
 

--- a/db/tables/table_details_line.sql
+++ b/db/tables/table_details_line.sql
@@ -13,6 +13,7 @@ SELECT
        when "natural" = 'cliff' then 'cliff'
        when highway is not null then 'dam_highway'
        when waterway = 'dam' then 'dam'
+       when waterway = 'weir' then 'weir'
   end AS kind,
   highway
 FROM
@@ -20,4 +21,4 @@ FROM
 WHERE
   (man_made = 'cutline' OR
    "natural" = 'cliff' OR
-   waterway = 'dam';
+   waterway in ('dam', 'weir');

--- a/db/update.sh
+++ b/db/update.sh
@@ -97,16 +97,14 @@ if [ -s dirty_tiles ]; then
     done
     rm generate_openmap_*_$DIRTY_FILE
 
-    ../tegola cache purge --config $TEGOLA_CONFIG_FILE --map="detail" tile-list dirty_tiles
-    ../tegola cache purge --config $TEGOLA_CONFIG_FILE --map="topo"   tile-list dirty_tiles
+    ../tegola cache purge --config $TEGOLA_CONFIG_FILE --map="detail"    tile-list dirty_tiles
+    ../tegola cache purge --config $TEGOLA_CONFIG_FILE --map="topo"      tile-list dirty_tiles
+    ../tegola cache purge --config $TEGOLA_CONFIG_FILE --map="river"     tile-list dirty_tiles
+    ../tegola cache purge --config $TEGOLA_CONFIG_FILE --map="craftbeer" tile-list dirty_tiles
 
     echo "Bicycle regenerate expired " `date`
     ../tegola cache purge --config $TEGOLA_CONFIG_FILE --map="bicycle" tile-list dirty_tiles
     ../tegola cache seed  --config $TEGOLA_CONFIG_FILE --map="bicycle" tile-list generate_bicycle_$DIRTY_FILE --overwrite --concurrency 3
-
-    echo "Craftbeer generate expired " `date`
-    ../tegola cache purge --config $TEGOLA_CONFIG_FILE --map="craftbeer" tile-list dirty_tiles
-    ../tegola cache seed  --config $TEGOLA_CONFIG_FILE --map="craftbeer" tile-list generate_craftbeer_$DIRTY_FILE --overwrite --concurrency 3
 
     echo "Done " `date`
 


### PR DESCRIPTION
1. Upėms pridėtas naujas atributas _virtual_, kurio reikšmė _N_ - tikra upė, _Y_ - virtuali (apytikslė trajektorija per vandens telkinį).
2. Atnaujinant db craftbeer išpurvintas kaladėles tik trinti, naujų negeneruoti.