### PR TITLE
Upių simbolizavimo pataisymai

### DIFF
--- a/demo/styles/hybrid_upes.json
+++ b/demo/styles/hybrid_upes.json
@@ -22,7 +22,7 @@
       "url": "https://openmap.lt/capabilities/river.json"
     }
   },
-  "sprite": "https://openmap.lt/webgl/sprites/river",
+  "sprite": "https://openmap.lt/sprites/river",
   "glyphs": "https://openmap.lt/glyphs/{fontstack}/{range}.pbf",
   "layers": [
     {
@@ -58,44 +58,6 @@
           3,
           7
         ]
-      }
-    },
-    {
-      "id": "boundary-national-park-outline",
-      "type": "line",
-      "source": "osm",
-      "source-layer": "protected",
-      "minzoom": 0,
-      "maxzoom": 20,
-      "filter": [
-        "all",
-        [
-          "==",
-          "kind",
-          "national_park"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
-      "paint": {
-        "line-color": "rgba(135, 199, 137, 1)",
-        "line-dasharray": [
-          2,
-          2
-        ],
-        "line-width": {
-          "stops": [
-            [
-              8,
-              2
-            ],
-            [
-              18,
-              4
-            ]
-          ]
-        }
       }
     },
     {
@@ -454,7 +416,6 @@
         ]
       ],
       "layout": {
-        "visibility": "visible",
         "symbol-placement": "line",
         "text-field": "{name}",
         "text-font": [
@@ -715,6 +676,42 @@
       }
     },
     {
+      "id": "label-icon-milestone",
+      "type": "symbol",
+      "source": "river",
+      "source-layer": "point",
+      "minzoom": 14,
+      "maxzoom": 20,
+      "filter": [
+        "all",
+        [
+          "!=",
+          "kind",
+          "milestone"
+        ]
+      ],
+      "layout": {
+        "text-field": "{name}",
+        "text-size": 12,
+        "text-max-width": 9,
+        "text-anchor": "center",
+        "text-font": [
+          "Roboto Condensed Italic"
+        ],
+        "text-padding": 1,
+        "visibility": "visible",
+        "text-offset": [
+          0,
+          1.8
+        ]
+      },
+      "paint": {
+        "text-color": "rgba(20, 20, 20, 1)",
+        "text-halo-width": 1.5,
+        "text-halo-color": "rgba(255, 255, 255, 0.7)"
+      }
+    },
+    {
       "id": "label-milestone",
       "type": "symbol",
       "source": "river",
@@ -737,8 +734,7 @@
         "text-font": [
           "Roboto Condensed Italic"
         ],
-        "text-padding": 1,
-        "visibility": "visible"
+        "text-padding": 1
       },
       "paint": {
         "text-color": "rgba(20, 20, 20, 1)",

--- a/demo/styles/topo.json
+++ b/demo/styles/topo.json
@@ -242,27 +242,6 @@
       }
     },
     {
-      "id": "landuse-park",
-      "type": "fill",
-      "source": "tilezen",
-      "source-layer": "landuse",
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "park"
-        ]
-      ],
-      "layout": {
-        "visibility": "none"
-      },
-      "paint": {
-        "fill-color": "rgba(122, 220, 125, 1)",
-        "fill-opacity": 0.5
-      }
-    },
-    {
       "id": "hillshading",
       "type": "hillshade",
       "source": "dem",
@@ -386,47 +365,6 @@
             ]
           ]
         }
-      }
-    },
-    {
-      "id": "waterway-river-direction",
-      "type": "line",
-      "source": "tilezen",
-      "source-layer": "water",
-      "minzoom": 16,
-      "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "kind",
-          "river"
-        ]
-      ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
-      "paint": {
-        "line-width": {
-          "base": 1.55,
-          "stops": [
-            [
-              4,
-              0.25
-            ],
-            [
-              20,
-              30
-            ]
-          ]
-        },
-        "line-pattern": "river",
-        "line-opacity": 0.6,
-        "line-translate": [
-          0,
-          0
-        ]
       }
     },
     {
@@ -563,6 +501,52 @@
         "fill-color": "#bed7f0",
         "fill-outline-color": "#49a5dd",
         "fill-antialias": false
+      }
+    },
+    {
+      "id": "waterway-river-direction",
+      "type": "line",
+      "source": "tilezen",
+      "source-layer": "water",
+      "minzoom": 16,
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        [
+          "==",
+          "kind",
+          "river"
+        ],
+        [
+          "==",
+          "virtual",
+          "N"
+        ]
+      ],
+      "layout": {
+        "line-join": "round",
+        "line-cap": "round"
+      },
+      "paint": {
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [
+              4,
+              0.25
+            ],
+            [
+              20,
+              30
+            ]
+          ]
+        },
+        "line-pattern": "river",
+        "line-opacity": 0.6,
+        "line-translate": [
+          0,
+          0
+        ]
       }
     },
     {
@@ -2451,6 +2435,11 @@
           "==",
           "$type",
           "LineString"
+        ],
+        [
+          "==",
+          "virtual",
+          "N"
         ]
       ],
       "layout": {

--- a/demo/styles/upes.json
+++ b/demo/styles/upes.json
@@ -246,27 +246,6 @@
       }
     },
     {
-      "id": "landuse-park",
-      "type": "fill",
-      "source": "tilezen",
-      "source-layer": "landuse",
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "park"
-        ]
-      ],
-      "layout": {
-        "visibility": "none"
-      },
-      "paint": {
-        "fill-color": "rgba(122, 220, 125, 1)",
-        "fill-opacity": 0.5
-      }
-    },
-    {
       "id": "hillshading",
       "type": "hillshade",
       "source": "dem",
@@ -400,47 +379,6 @@
             ]
           ]
         }
-      }
-    },
-    {
-      "id": "waterway-river-direction",
-      "type": "line",
-      "source": "tilezen",
-      "source-layer": "water",
-      "minzoom": 16,
-      "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "kind",
-          "river"
-        ]
-      ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
-      "paint": {
-        "line-width": {
-          "base": 1.55,
-          "stops": [
-            [
-              4,
-              0.25
-            ],
-            [
-              20,
-              30
-            ]
-          ]
-        },
-        "line-pattern": "river",
-        "line-opacity": 0.6,
-        "line-translate": [
-          0,
-          0
-        ]
       }
     },
     {
@@ -609,6 +547,52 @@
             ]
           ]
         }
+      }
+    },
+    {
+      "id": "waterway-river-direction",
+      "type": "line",
+      "source": "tilezen",
+      "source-layer": "water",
+      "minzoom": 16,
+      "maxzoom": 24,
+      "filter": [
+        "all",
+        [
+          "==",
+          "kind",
+          "river"
+        ],
+        [
+          "==",
+          "virtual",
+          "N"
+        ]
+      ],
+      "layout": {
+        "line-join": "round",
+        "line-cap": "round"
+      },
+      "paint": {
+        "line-width": {
+          "base": 1.55,
+          "stops": [
+            [
+              4,
+              0.25
+            ],
+            [
+              20,
+              30
+            ]
+          ]
+        },
+        "line-pattern": "river",
+        "line-opacity": 0.6,
+        "line-translate": [
+          0,
+          0
+        ]
       }
     },
     {


### PR DESCRIPTION
Pataisymai topo, upių ir hibridiniame upių žemėlapiuose.
1. Vandens tekėjimo krypties rodyklė pakelta virš _waterway=riverbank_.
2. Vandens tekėjimo krypties rodyklė nerodoma virtualiose upėse (virš vandens telkinių).
3. Upių žemėlapyje išimtos nacionalinių parkų ribos.