### PR TITLE
Pridėtas 'airstrip' naudojmas

### DIFF
--- a/data/topo/z10.pgsql
+++ b/data/topo/z10.pgsql
@@ -6,7 +6,7 @@ SELECT
   name,
   (
     CASE
-    WHEN aeroway = 'aerodrome'
+    WHEN aeroway in ('aerodrome', 'airstrip')
       THEN 'airport'
     WHEN amenity = 'place_of_worship' and building = 'chapel'
       THEN 'chapel'

--- a/data/topo/z16.pgsql
+++ b/data/topo/z16.pgsql
@@ -6,7 +6,7 @@ SELECT
   name,
   (
     CASE
-    WHEN aeroway = 'aerodrome'
+    WHEN aeroway in ('aerodrome', 'airstrip')
       THEN 'airport'
     WHEN amenity = 'place_of_worship' and building = 'chapel'
       THEN 'chapel'

--- a/db/tables/table_poi_topo.sql
+++ b/db/tables/table_poi_topo.sql
@@ -37,7 +37,7 @@ create materialized view poi_topo (
         ,voltage
         ,way
     from planet_osm_point
-   where aeroway in ('aerodrome', 'helipad')
+   where aeroway in ('aerodrome', 'airstrip', 'helipad')
       or amenity = 'place_of_worship'
       or man_made in ('chimney', 'windmill', 'watermill', 'tower', 'communications_tower', 'lighthouse', 'water_tower', 'mast')
       or amenity = 'fuel'
@@ -64,7 +64,7 @@ create materialized view poi_topo (
         ,voltage
         ,st_centroid(way)
     from planet_osm_polygon
-   where aeroway in ('aerodrome', 'helipad')
+   where aeroway in ('aerodrome', 'airstrip', 'helipad')
       or amenity = 'place_of_worship'
       or man_made in ('chimney', 'windmill', 'watermill', 'tower', 'communications_tower', 'lighthouse', 'water_tower', 'mast')
       or amenity = 'fuel'


### PR DESCRIPTION
Oro uostai gali būti pažymėti ne tik _aeroway=aerodrome_, bet dar ir _aeroway=airstrip_.
![paveikslas](https://user-images.githubusercontent.com/969513/61576206-b3a6e900-aadf-11e9-8bbd-072148089074.png)
