### PR TITLE
Parametrų tinkinimas

### DIFF
--- a/data/buildings/z12.pgsql
+++ b/data/buildings/z12.pgsql
@@ -8,5 +8,5 @@ FROM
   gen_building
 WHERE
   way && !BBOX! AND
-  way_area > 320 AND
+  way_area > 200 AND
   res = 10

--- a/data/buildings/z13.pgsql
+++ b/data/buildings/z13.pgsql
@@ -8,5 +8,4 @@ FROM
   gen_building
 WHERE
   way && !BBOX! AND
-  way_area > 160 AND
   res = 10

--- a/data/buildings/z14.pgsql
+++ b/data/buildings/z14.pgsql
@@ -8,5 +8,5 @@ FROM
   gen_building
 WHERE
   way && !BBOX! AND
-  way_area > 80 AND
+  way_area > 50 AND
   res = 5

--- a/db/func/stc_process_centerlines.sql
+++ b/db/func/stc_process_centerlines.sql
@@ -147,7 +147,7 @@ begin
       if big_enough_centroid then
         l = greatest((st_xmax(c.way) - st_xmin(c.way)) / pixelsize,
                      (st_ymax(c.way) - st_ymin(c.way)) / pixelsize);
-        if l > 50 then
+        if l > 40 then
           raise notice 'Big enough for centroid label';
           s = cast(l as float) / c.l * 28;
           raise notice '% / % * 28 = %', l, c.l, s;


### PR DESCRIPTION
1. Rodoma daugiau (mažesnių) pastatų.
2. Taškinės vandens telkinių etiketės rodomos, kai telkinio vizualus plotas yra bent 40 taškų (buvo bent 50 taškų).