### PR TITLE
Pastatų generalizavimas/tipifikavimas

### DIFF
--- a/data/buildings/z12.pgsql
+++ b/data/buildings/z12.pgsql
@@ -8,5 +8,4 @@ FROM
   gen_building
 WHERE
   way && !BBOX! AND
-  way_area > 200 AND
-  res = 10
+  res = 40

--- a/data/buildings/z13.pgsql
+++ b/data/buildings/z13.pgsql
@@ -8,4 +8,4 @@ FROM
   gen_building
 WHERE
   way && !BBOX! AND
-  res = 10
+  res = 20

--- a/data/buildings/z14.pgsql
+++ b/data/buildings/z14.pgsql
@@ -8,5 +8,4 @@ FROM
   gen_building
 WHERE
   way && !BBOX! AND
-  way_area > 50 AND
-  res = 5
+  res = 10

--- a/data/buildings/z15.pgsql
+++ b/data/buildings/z15.pgsql
@@ -1,12 +1,11 @@
 SELECT
-  osm_id AS gid,
+  id AS gid,
   st_asbinary(way) AS geom,
-  building AS kind,
-  coalesce(name, "addr:housename") AS name,
-  coalesce(cast(split_part(height, '.', 1) as integer), coalesce(cast("building:levels" as integer), 2) * 3) AS height
+  'yes' AS kind,
+  null AS name,
+  null AS height
 FROM
-  planet_osm_polygon
+  gen_building
 WHERE
   way && !BBOX! AND
-  building IS NOT NULL AND
-  way_area > 40
+  res = 5

--- a/db/func/stc_simplify_building_line.sql
+++ b/db/func/stc_simplify_building_line.sql
@@ -245,9 +245,13 @@ begin
                  );
             np = st_intersection(l1, l2);
             if not st_isempty(np) then
-              fg = st_setpoint(fg, sn-2, np);
-              fg = st_setpoint(fg, sn-3, np);
-              --fg = st_setpoint(fg, sn-3, np);
+              if st_distance(np, fg) > t then
+                ex = st_union(ex, edge);
+              else
+                fg = st_setpoint(fg, sn-2, np);
+                fg = st_setpoint(fg, sn-3, np);
+                --fg = st_setpoint(fg, sn-3, np);
+              end if;
             else
               raise notice 'TODO A';
               ex = st_union(ex, edge);
@@ -389,9 +393,9 @@ begin
         ex = st_union(ex, edge);
       end if;
 
-    -----------------
-    -- UNPOCESSABLE
-    -----------------
+    ------------------
+    -- UNPROCESSABLE
+    ------------------
     elseif (ac between -160 and -110) or
            (ac between -50 and -40) or
            (ac between 40 and 50) or
@@ -408,12 +412,14 @@ begin
     fg = stc_simplify_turbo(fg);
 
     -- debug
-    if dg then insert into temp values (2, l1); end if;
-    if dg then insert into temp values (2, l2); end if;
-    if dg then insert into temp values (3, np); end if;
-    if dg then insert into temp values (3, np2); end if;
-    if dg then insert into temp values (4, fg); end if;
-    if dg then insert into temp values (9, ex); end if;
+    if dg then
+      insert into temp values (2, l1);
+      insert into temp values (2, l2);
+      insert into temp values (3, np);
+      insert into temp values (3, np2);
+      insert into temp values (4, fg);
+      insert into temp values (9, ex);
+    end if;
 
     fg = stc_remove_spike(fg);
     fg = stc_simplify_angle(fg);


### PR DESCRIPTION
1. Pataisyta pastatų paprastinimo klaida, kai geometrijos išorinis taškas būdavo perkeliamas tooooli nuo pradinio perimetro.
2. Pastatų paprastinimas/tipifikavimas iki 20 ir 40 metrų.
3. Smulkesniuose masteliuose naudojami stipriau supaprastinti/tipifikuoti pastatai.