### PR TITLE
Pridėtas landcover=trees|grass

### DIFF
--- a/db/osm2pgsql.style
+++ b/db/osm2pgsql.style
@@ -167,6 +167,7 @@ node,way   craft        text         polygon
 way        track        text         linear
 way        footway      text         linear
 node,way   voltage      text         linear
+way        landcover    text         linear
 node,way   z_order      int4         linear # This is calculated during import
 way        way_area     real                # This is calculated during import
 node,way   osm_timestamp timestamptz(0)

--- a/db/tables/table_details_poly.sql
+++ b/db/tables/table_details_poly.sql
@@ -9,8 +9,9 @@ SELECT
   osm_id,
   ST_AsBinary(way),
   way,
-  leisure AS kind
+  coalesce(leisure, landcover) AS kind
 FROM
   planet_osm_polygon
 WHERE
-  leisure in ('stadium', 'pitch');
+  leisure in ('stadium', 'pitch') or
+  landcover in ('grass', 'trees');

--- a/demo/styles/map.json
+++ b/demo/styles/map.json
@@ -382,6 +382,44 @@
       }
     },
     {
+      "id": "landcover-trees",
+      "type": "fill",
+      "source": "detail",
+      "source-layer": "detail_poly",
+      "minzoom": 16,
+      "filter": [
+        "all",
+        [
+          "in",
+          "kind",
+          "trees"
+        ]
+      ],
+      "paint": {
+        "fill-color": "rgba(136, 220, 122, 1)",
+        "fill-opacity": 1
+      }
+    },
+    {
+      "id": "landcover-grass",
+      "type": "fill",
+      "source": "detail",
+      "source-layer": "detail_poly",
+      "minzoom": 16,
+      "filter": [
+        "all",
+        [
+          "in",
+          "kind",
+          "grass"
+        ]
+      ],
+      "paint": {
+        "fill-color": "rgba(205, 235, 176, 1)",
+        "fill-opacity": 1
+      }
+    },
+    {
       "id": "detail-stadium",
       "type": "fill",
       "source": "detail",


### PR DESCRIPTION
Į žemėlapio detalių poligonų sluoksnį pridėti _landcover=grass|trees_ elementai.
Jie rodomi stambiuose masteliuose virš _landuse_ poligonų.