### PR TITLE
Paieškos rezultatų piktogramos

### DIFF
--- a/demo/search/search.js
+++ b/demo/search/search.js
@@ -166,7 +166,6 @@ function imgSprite(name, value) {
     } else {
       icon = typeIcons.default;
     }
-    console.log(name + '=' + value + '=>' + icon);
     return '<img src="img_trans.gif" style="width: ' + sprite[icon].width +
            'px; height: ' + sprite[icon].height +
            'px; background: url(search/sprites/openmaplt.png) -' + sprite[icon].x + 'px -' + sprite[icon].y + 'px;">';

--- a/demo/search/search.js
+++ b/demo/search/search.js
@@ -1,3 +1,104 @@
+var typeIcons = {
+   amenity: {
+     arts_centre: 'arg-gallery',
+     atm: 'marker',
+     bank: 'bank',
+     bar: 'bar',
+     bicycle_parking: 'bicycle_parking',
+     bicycle_rental: 'bicycle_rental',
+     bus_station: 'bus',
+     cafe: 'cafe',
+     car_wash: 'marker',
+     cinema: 'cinema',
+     clinic: 'marker',
+     courthouse: 'marker',
+     compressed_air: 'compressed_air',
+     dentist: 'dentist',
+     doctors: 'doctor',
+     fast_food: 'fast-food',
+     ferry_terminal: 'ferry',
+     fire_station: 'fire-station',
+     fuel: 'fuel',
+     hospital: 'hospital',
+     kindergarten: 'scooter',
+     library: 'library',
+     pharmacy: 'pharmacy',
+     place_of_worship: 'place_of_worship',
+     police: 'police',
+     post_office: 'post',
+     pub: 'beer',
+     restaurant: 'restaurant',
+     school: 'school',
+     shelter: 'shelter',
+     theatre: 'theatre',
+     townhall: 'town-hall',
+     college: 'college',
+     university: 'college',
+     default: 'marker'
+   },
+   man_made: {
+     tower: 'marker',
+     default: 'marker'
+   },
+   tourism: {
+     attraction: 'attraction',
+     information: 'information',
+     camp_site: 'campsite',
+     caravan_site: 'campsite',
+     chalet: 'home',
+     hostel: 'home',
+     motel: 'home',
+     guest_house: 'home',
+     hotel: 'lodging',
+     museum: 'museum',
+     picnic_site: 'picnic-site',
+     viewpoint: 'viewpoint',
+     zoo: 'zoo',
+     theme_park: 'theme_park',
+     default: 'marker'
+   },
+   historic: {
+     archaeological_site: 'hillfort',
+     memorial: 'memorial',
+     manor: 'marker',
+     monastery: 'marker',
+     default: 'marker'
+   },
+   railway: {
+     station: 'rail',
+     default: 'marker'
+   },
+   aeroway: {
+     terminal: 'airport',
+     helipad: 'heliport',
+     aerodrome: 'airfield',
+     default: 'marker'
+   },
+   shop: {
+     alcohol: 'alcohol-shop',
+     car_repair: 'marker',
+     bakery: 'bakery',
+     bicycle: 'bicycle',
+     clothes: 'clothing-store',
+     supermarket: 'grocery',
+     mall: 'grocery',
+     department_store: 'grocery',
+     convenience: 'shop',
+     hairdresser: 'hairdresser',
+     florist: 'florist',
+     music: 'music',
+     butcher: 'slaughterhouse',
+     default: 'shop'
+   },
+   office: {
+     government: 'town-hall',
+     notary: 'marker',
+     lawyer: 'marker',
+     default: 'marker'
+   },
+   default: 'marker'
+};
+
 var formatResult = function () {
     return function (feature) {
         var formatted = '';
@@ -54,13 +155,21 @@ xmlhttp.onreadystatechange = function() {
 xmlhttp.open("GET", "search/sprites/openmaplt.json", true);
 xmlhttp.send();
 
-function imgSprite(name) {
-    if (sprite[name]) {
-        return '<img src="img_trans.gif" style="width: ' + sprite[name].width +
-            'px; height: ' + sprite[name].height +
-            'px; background: url(search/sprites/openmaplt.png) -' + sprite[name].x + 'px -' + sprite[name].y + 'px;">';
+function imgSprite(name, value) {
+    var icon;
+    if (typeIcons[name]) {
+      if (typeIcons[name][value]) {
+        icon = typeIcons[name][value];
+      } else {
+        icon = typeIcons[name].default;
+      }
+    } else {
+      icon = typeIcons.default;
     }
-    return '<img src="img_trans.gif" />';
+    console.log(name + '=' + value + '=>' + icon);
+    return '<img src="img_trans.gif" style="width: ' + sprite[icon].width +
+           'px; height: ' + sprite[icon].height +
+           'px; background: url(search/sprites/openmaplt.png) -' + sprite[icon].x + 'px -' + sprite[icon].y + 'px;">';
 }
 
 $('#searchInput').typeahead({
@@ -74,7 +183,7 @@ $('#searchInput').typeahead({
     templates: {
         suggestion: function (context) {
          console.log(context);
-         return '<div>' + imgSprite(context.properties.osm_key) + context.description + '</div>';
+         return '<div>' + imgSprite(context.properties.osm_key, context.properties.osm_value) + context.description + '</div>';
         }
     }
 });

--- a/demo/search/search.js
+++ b/demo/search/search.js
@@ -156,15 +156,9 @@ xmlhttp.open("GET", "search/sprites/openmaplt.json", true);
 xmlhttp.send();
 
 function imgSprite(name, value) {
-    var icon;
+    var icon = typeIcons.default;
     if (typeIcons[name]) {
-      if (typeIcons[name][value]) {
-        icon = typeIcons[name][value];
-      } else {
-        icon = typeIcons[name].default;
-      }
-    } else {
-      icon = typeIcons.default;
+      icon = typeIcons[name][value] || typeIcons[name].default;
     }
     return '<img src="img_trans.gif" style="width: ' + sprite[icon].width +
            'px; height: ' + sprite[icon].height +


### PR DESCRIPTION
Paieškos rezultatų piktogramos parenkamos tokios pačios, kaip ir rodomos pagrindiniame openmap.lt žemėlapyje.
Tiek kiek išeina, nes kai kurios piktogramos parenkamos pagal daugiau nei vieną reikšmę, o dabartinis paieškos variklis grąžina tik vieną reikšmę, taigi pvz. negalima atskirti piliakalnio nuo pilkapio arba lankytinos vietos nuo pažintinio tako.