### PR TITLE
Pagalbiniai geležinkeliai ir geležinkelio žemėnauda

### DIFF
--- a/data/landuse/z14.pgsql
+++ b/data/landuse/z14.pgsql
@@ -8,7 +8,7 @@ SELECT
       WHEN landuse = 'retail'
         THEN 'commercial'
       WHEN landuse = 'railway'
-        THEN 'railway'
+        THEN 'industrial'
       WHEN landuse is not null
         THEN landuse
       WHEN "natural" = 'wetland' AND "wetland" = 'marsh'

--- a/demo/styles/topo.json
+++ b/demo/styles/topo.json
@@ -1,9 +1,7 @@
 {
   "version": 8,
   "name": "openmap.lt",
-  "metadata": {
-    "maputnik:renderer": "mbgljs"
-  },
+  "metadata": {"maputnik:renderer": "mbgljs"},
   "sources": {
     "tilezen": {
       "type": "vector",
@@ -28,24 +26,15 @@
     {
       "id": "background",
       "type": "background",
-      "paint": {
-        "background-color": "#eeeeee"
-      }
+      "paint": {"background-color": "#eeeeee"}
     },
     {
       "id": "coastline",
       "type": "fill",
       "source": "tilezen",
       "source-layer": "coastline",
-      "filter": [
-        "==",
-        "kind",
-        "coastline"
-      ],
-      "paint": {
-        "fill-color": "#bed7f0",
-        "fill-outline-color": "#49a5dd"
-      }
+      "filter": ["==", "kind", "coastline"],
+      "paint": {"fill-color": "#bed7f0", "fill-outline-color": "#49a5dd"}
     },
     {
       "id": "landuse-forest",
@@ -53,18 +42,8 @@
       "source": "tilezen",
       "source-layer": "landuse",
       "minzoom": 7,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "forest"
-        ]
-      ],
-      "paint": {
-        "fill-color": "#cbe3a9",
-        "fill-opacity": 1
-      }
+      "filter": ["all", ["in", "kind", "forest"]],
+      "paint": {"fill-color": "#cbe3a9", "fill-opacity": 1}
     },
     {
       "id": "landuse-orchard-sym",
@@ -72,17 +51,8 @@
       "source": "tilezen",
       "source-layer": "landuse",
       "minzoom": 7,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "orchard"
-        ]
-      ],
-      "paint": {
-        "fill-pattern": "orchard"
-      }
+      "filter": ["all", ["in", "kind", "orchard"]],
+      "paint": {"fill-pattern": "orchard"}
     },
     {
       "id": "landuse-cemetery",
@@ -90,17 +60,8 @@
       "source": "tilezen",
       "source-layer": "landuse",
       "minzoom": 7,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "cemetery"
-        ]
-      ],
-      "paint": {
-        "fill-pattern": "cemetery"
-      }
+      "filter": ["all", ["in", "kind", "cemetery"]],
+      "paint": {"fill-pattern": "cemetery"}
     },
     {
       "id": "landuse-meadow",
@@ -108,17 +69,8 @@
       "source": "tilezen",
       "source-layer": "landuse",
       "minzoom": 6,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "meadow"
-        ]
-      ],
-      "paint": {
-        "fill-pattern": "meadow"
-      }
+      "filter": ["all", ["in", "kind", "meadow"]],
+      "paint": {"fill-pattern": "meadow"}
     },
     {
       "id": "landuse-sand",
@@ -127,18 +79,8 @@
       "source-layer": "landuse",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "sand"
-        ]
-      ],
-      "paint": {
-        "fill-color": "#fffacd",
-        "fill-opacity": 1
-      }
+      "filter": ["all", ["in", "kind", "sand"]],
+      "paint": {"fill-color": "#fffacd", "fill-opacity": 1}
     },
     {
       "id": "landuse-marsh",
@@ -146,17 +88,8 @@
       "source": "tilezen",
       "source-layer": "landuse",
       "minzoom": 6,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "marsh"
-        ]
-      ],
-      "paint": {
-        "fill-pattern": "marsh"
-      }
+      "filter": ["all", ["in", "kind", "marsh"]],
+      "paint": {"fill-pattern": "marsh"}
     },
     {
       "id": "landuse-swamp",
@@ -164,17 +97,8 @@
       "source": "tilezen",
       "source-layer": "landuse",
       "minzoom": 7,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "swamp"
-        ]
-      ],
-      "paint": {
-        "fill-pattern": "swamp"
-      }
+      "filter": ["all", ["in", "kind", "swamp"]],
+      "paint": {"fill-pattern": "swamp"}
     },
     {
       "id": "landuse-residential",
@@ -184,13 +108,7 @@
       "minzoom": 6,
       "filter": [
         "all",
-        [
-          "in",
-          "kind",
-          "residential",
-          "allotments",
-          "commercial"
-        ]
+        ["in", "kind", "residential", "allotments", "commercial"]
       ],
       "paint": {
         "fill-color": "rgba(221, 221, 221, 1)",
@@ -204,15 +122,7 @@
       "source": "tilezen",
       "source-layer": "landuse",
       "minzoom": 6,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "industrial",
-          "farmyard"
-        ]
-      ],
+      "filter": ["all", ["in", "kind", "industrial", "farmyard"]],
       "paint": {
         "fill-color": "rgba(210, 190, 210, 1)",
         "fill-opacity": 1,
@@ -224,9 +134,7 @@
       "type": "hillshade",
       "source": "dem",
       "minzoom": 9,
-      "paint": {
-        "hillshade-exaggeration": 0.5
-      }
+      "paint": {"hillshade-exaggeration": 0.5}
     },
     {
       "id": "waterway-other",
@@ -234,34 +142,10 @@
       "source": "tilezen",
       "source-layer": "water",
       "minzoom": 14,
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "in",
-          "kind",
-          "ditch"
-        ]
-      ],
+      "filter": ["all", ["==", "$type", "LineString"], ["in", "kind", "ditch"]],
       "paint": {
         "line-color": "#49a5dd",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              14,
-              1
-            ],
-            [
-              18,
-              3
-            ]
-          ]
-        }
+        "line-width": {"base": 1.2, "stops": [[14, 1], [18, 3]]}
       }
     },
     {
@@ -270,38 +154,11 @@
       "source": "tilezen",
       "source-layer": "water",
       "minzoom": 6,
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "==",
-          "kind",
-          "river"
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "filter": ["all", ["==", "$type", "LineString"], ["==", "kind", "river"]],
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-color": "#49a5dd",
-        "line-width": {
-          "base": 1.2,
-          "stops": [
-            [
-              8,
-              0.75
-            ],
-            [
-              20,
-              15
-            ]
-          ]
-        }
+        "line-width": {"base": 1.2, "stops": [[8, 0.75], [20, 15]]}
       }
     },
     {
@@ -312,44 +169,15 @@
       "minzoom": 11,
       "filter": [
         "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "in",
-          "kind",
-          "stream",
-          "canal"
-        ]
+        ["==", "$type", "LineString"],
+        ["in", "kind", "stream", "canal"]
       ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-color": "#49a5dd",
         "line-width": {
           "base": 1.4,
-          "stops": [
-            [
-              10,
-              0.5
-            ],
-            [
-              14,
-              1
-            ],
-            [
-              15,
-              3
-            ],
-            [
-              18,
-              10
-            ]
-          ]
+          "stops": [[10, 0.5], [14, 1], [15, 3], [18, 10]]
         }
       }
     },
@@ -361,37 +189,13 @@
       "minzoom": 15,
       "filter": [
         "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "in",
-          "kind",
-          "stream",
-          "canal"
-        ]
+        ["==", "$type", "LineString"],
+        ["in", "kind", "stream", "canal"]
       ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-color": "#bed7f0",
-        "line-width": {
-          "base": 1.4,
-          "stops": [
-            [
-              15,
-              1
-            ],
-            [
-              18,
-              8
-            ]
-          ]
-        }
+        "line-width": {"base": 1.4, "stops": [[15, 1], [18, 8]]}
       }
     },
     {
@@ -401,27 +205,13 @@
       "source-layer": "water",
       "minzoom": 16,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "stream",
-          "canal"
-        ]
-      ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "filter": ["all", ["in", "kind", "stream", "canal"]],
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
         "line-width": 16,
         "line-pattern": "stream",
         "line-opacity": 0.6,
-        "line-translate": [
-          0,
-          0
-        ]
+        "line-translate": [0, 0]
       }
     },
     {
@@ -429,11 +219,7 @@
       "type": "fill",
       "source": "tilezen",
       "source-layer": "water",
-      "filter": [
-        "==",
-        "$type",
-        "Polygon"
-      ],
+      "filter": ["==", "$type", "Polygon"],
       "paint": {
         "fill-color": "#bed7f0",
         "fill-outline-color": "#49a5dd",
@@ -445,25 +231,10 @@
       "type": "line",
       "source": "tilezen",
       "source-layer": "water",
-      "filter": [
-        "==",
-        "$type",
-        "Polygon"
-      ],
+      "filter": ["==", "$type", "Polygon"],
       "paint": {
         "line-color": "#49a5dd",
-        "line-width": {
-          "stops": [
-            [
-              7,
-              0
-            ],
-            [
-              12,
-              1
-            ]
-          ]
-        }
+        "line-width": {"stops": [[7, 0], [12, 1]]}
       }
     },
     {
@@ -473,38 +244,11 @@
       "source-layer": "water",
       "minzoom": 12,
       "maxzoom": 20,
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "in",
-          "kind",
-          "river"
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "filter": ["all", ["==", "$type", "LineString"], ["in", "kind", "river"]],
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-color": "#bed7f0",
-        "line-width": {
-          "base": 1.4,
-          "stops": [
-            [
-              8,
-              0.5
-            ],
-            [
-              20,
-              15
-            ]
-          ]
-        }
+        "line-width": {"base": 1.4, "stops": [[8, 0.5], [20, 15]]}
       }
     },
     {
@@ -514,37 +258,10 @@
       "source-layer": "water",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "kind",
-          "river"
-        ],
-        [
-          "==",
-          "virtual",
-          "N"
-        ]
-      ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "filter": ["all", ["==", "kind", "river"], ["==", "virtual", "N"]],
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
-        "line-width": {
-          "base": 1.55,
-          "stops": [
-            [
-              4,
-              0.25
-            ],
-            [
-              20,
-              30
-            ]
-          ]
-        },
+        "line-width": {"base": 1.55, "stops": [[4, 0.25], [20, 30]]},
         "line-pattern": "river",
         "line-opacity": 0.6
       }
@@ -556,24 +273,11 @@
       "source-layer": "detail_poly",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "kind",
-          "stadium"
-        ]
-      ],
+      "filter": ["all", ["==", "kind", "stadium"]],
       "paint": {
         "line-width": 0.5,
-        "line-dasharray": [
-          12,
-          6
-        ],
-        "line-translate": [
-          0,
-          0
-        ],
+        "line-dasharray": [12, 6],
+        "line-translate": [0, 0],
         "line-offset": 3
       }
     },
@@ -584,21 +288,8 @@
       "source-layer": "detail_line",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "kind",
-          "cutline"
-        ]
-      ],
-      "paint": {
-        "line-width": 0.5,
-        "line-dasharray": [
-          12,
-          6
-        ]
-      }
+      "filter": ["all", ["==", "kind", "cutline"]],
+      "paint": {"line-width": 0.5, "line-dasharray": [12, 6]}
     },
     {
       "id": "detail-cliff",
@@ -607,18 +298,8 @@
       "source-layer": "detail_line",
       "minzoom": 14,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "kind",
-          "cliff"
-        ]
-      ],
-      "paint": {
-        "line-pattern": "cliff",
-        "line-width": 5
-      }
+      "filter": ["all", ["==", "kind", "cliff"]],
+      "paint": {"line-pattern": "cliff", "line-width": 5}
     },
     {
       "id": "landuse-reedbed",
@@ -626,17 +307,8 @@
       "source": "tilezen",
       "source-layer": "landuse",
       "minzoom": 6,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "reedbed"
-        ]
-      ],
-      "paint": {
-        "fill-pattern": "reedbed"
-      }
+      "filter": ["all", ["in", "kind", "reedbed"]],
+      "paint": {"fill-pattern": "reedbed"}
     },
     {
       "id": "dam-teeth-highway",
@@ -647,42 +319,14 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "kind",
-          "dam_highway"
-        ],
-        [
-          "!in",
-          "highway",
-          "footway",
-          "path",
-          "track"
-        ]
+        ["==", "kind", "dam_highway"],
+        ["!in", "highway", "footway", "path", "track"]
       ],
       "paint": {
         "line-width": 4,
-        "line-offset": {
-          "stops": [
-            [
-              13,
-              1
-            ],
-            [
-              15,
-              4
-            ],
-            [
-              18,
-              9
-            ]
-          ]
-        },
+        "line-offset": {"stops": [[13, 1], [15, 4], [18, 9]]},
         "line-opacity": 1,
-        "line-dasharray": [
-          0.4,
-          0.7
-        ],
+        "line-dasharray": [0.4, 0.7],
         "line-color": "#444444"
       }
     },
@@ -695,27 +339,14 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "in",
-          "kind",
-          "dam_highway"
-        ],
-        [
-          "in",
-          "highway",
-          "footway",
-          "path",
-          "track"
-        ]
+        ["in", "kind", "dam_highway"],
+        ["in", "highway", "footway", "path", "track"]
       ],
       "paint": {
         "line-width": 4,
         "line-offset": 3,
         "line-opacity": 1,
-        "line-dasharray": [
-          0.4,
-          0.7
-        ],
+        "line-dasharray": [0.4, 0.7],
         "line-color": "#444444"
       }
     },
@@ -728,32 +359,11 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "kind",
-          "dam_highway"
-        ],
-        [
-          "in",
-          "highway",
-          "footway",
-          "track",
-          "path"
-        ]
+        ["==", "kind", "dam_highway"],
+        ["in", "highway", "footway", "track", "path"]
       ],
       "paint": {
-        "line-width": {
-          "stops": [
-            [
-              13,
-              1
-            ],
-            [
-              15,
-              4
-            ]
-          ]
-        },
+        "line-width": {"stops": [[13, 1], [15, 4]]},
         "line-offset": 0,
         "line-opacity": 1,
         "line-color": "#444444"
@@ -768,32 +378,11 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "kind",
-          "dam_highway"
-        ],
-        [
-          "in",
-          "highway",
-          "footway",
-          "track",
-          "path"
-        ]
+        ["==", "kind", "dam_highway"],
+        ["in", "highway", "footway", "track", "path"]
       ],
       "paint": {
-        "line-width": {
-          "stops": [
-            [
-              13,
-              1
-            ],
-            [
-              15,
-              1.5
-            ]
-          ]
-        },
+        "line-width": {"stops": [[13, 1], [15, 1.5]]},
         "line-offset": 0,
         "line-opacity": 1,
         "line-color": "#eeeeee"
@@ -806,22 +395,12 @@
       "source-layer": "detail_line",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "dam"
-        ]
-      ],
+      "filter": ["all", ["in", "kind", "dam"]],
       "paint": {
         "line-width": 4,
         "line-offset": 3,
         "line-opacity": 1,
-        "line-dasharray": [
-          0.4,
-          0.7
-        ],
+        "line-dasharray": [0.4, 0.7],
         "line-color": "#444444"
       }
     },
@@ -832,27 +411,9 @@
       "source-layer": "detail_line",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "kind",
-          "dam"
-        ]
-      ],
+      "filter": ["all", ["==", "kind", "dam"]],
       "paint": {
-        "line-width": {
-          "stops": [
-            [
-              13,
-              1
-            ],
-            [
-              15,
-              3
-            ]
-          ]
-        },
+        "line-width": {"stops": [[13, 1], [15, 3]]},
         "line-offset": 0,
         "line-opacity": 1,
         "line-color": "#444444"
@@ -865,32 +426,11 @@
       "source-layer": "protected",
       "minzoom": 0,
       "maxzoom": 20,
-      "filter": [
-        "all",
-        [
-          "==",
-          "kind",
-          "national_park"
-        ]
-      ],
+      "filter": ["all", ["==", "kind", "national_park"]],
       "paint": {
         "line-color": "#85c4a5",
-        "line-dasharray": [
-          2,
-          4
-        ],
-        "line-width": {
-          "stops": [
-            [
-              8,
-              1
-            ],
-            [
-              18,
-              3
-            ]
-          ]
-        }
+        "line-dasharray": [2, 4],
+        "line-width": {"stops": [[8, 1], [18, 3]]}
       }
     },
     {
@@ -900,26 +440,10 @@
       "source-layer": "protected",
       "minzoom": 7,
       "maxzoom": 12,
-      "filter": [
-        "all",
-        [
-          "==",
-          "kind",
-          "national_park"
-        ]
-      ],
+      "filter": ["all", ["==", "kind", "national_park"]],
       "paint": {
         "fill-color": {
-          "stops": [
-            [
-              7,
-              "rgba(34, 183, 44, 0.2)"
-            ],
-            [
-              12,
-              "rgba(34, 183, 44, 0)"
-            ]
-          ]
+          "stops": [[7, "rgba(34, 183, 44, 0.2)"], [12, "rgba(34, 183, 44, 0)"]]
         }
       }
     },
@@ -930,33 +454,11 @@
       "source-layer": "boundaries",
       "minzoom": 0,
       "maxzoom": 20,
-      "filter": [
-        "all",
-        [
-          "==",
-          "kind",
-          "country"
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "filter": ["all", ["==", "kind", "country"]],
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-color": "#eb9dcb",
-        "line-width": {
-          "base": 2,
-          "stops": [
-            [
-              1,
-              1
-            ],
-            [
-              7,
-              3
-            ]
-          ]
-        },
+        "line-width": {"base": 2, "stops": [[1, 1], [7, 3]]},
         "line-translate-anchor": "map"
       }
     },
@@ -965,37 +467,12 @@
       "type": "line",
       "source": "tilezen",
       "source-layer": "roads",
-      "filter": [
-        "any",
-        [
-          "==",
-          "is_tunnel",
-          "yes"
-        ]
-      ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "filter": ["any", ["==", "is_tunnel", "yes"]],
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
         "line-color": "#afd3d3",
-        "line-width": {
-          "base": 1.55,
-          "stops": [
-            [
-              4,
-              0.25
-            ],
-            [
-              20,
-              30
-            ]
-          ]
-        },
-        "line-dasharray": [
-          1,
-          2
-        ]
+        "line-width": {"base": 1.55, "stops": [[4, 0.25], [20, 30]]},
+        "line-dasharray": [1, 2]
       }
     },
     {
@@ -1005,27 +482,9 @@
       "source-layer": "buildings",
       "minzoom": 12,
       "maxzoom": 20,
-      "filter": [
-        "all",
-        [
-          "==",
-          "kind",
-          "ruins"
-        ]
-      ],
+      "filter": ["all", ["==", "kind", "ruins"]],
       "paint": {
-        "line-width": {
-          "stops": [
-            [
-              14,
-              0.5
-            ],
-            [
-              16,
-              2
-            ]
-          ]
-        },
+        "line-width": {"stops": [[14, 0.5], [16, 2]]},
         "line-color": "#444444"
       }
     },
@@ -1036,17 +495,8 @@
       "source-layer": "buildings",
       "minzoom": 12,
       "maxzoom": 20,
-      "filter": [
-        "all",
-        [
-          "!=",
-          "kind",
-          "ruins"
-        ]
-      ],
-      "paint": {
-        "fill-color": "#444444"
-      }
+      "filter": ["all", ["!=", "kind", "ruins"]],
+      "paint": {"fill-color": "#444444"}
     },
     {
       "id": "road-track-bkg",
@@ -1055,33 +505,11 @@
       "source-layer": "roads",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "track"
-        ]
-      ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "filter": ["all", ["in", "kind", "track"]],
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
         "line-color": "rgba(255, 255, 255, 0.4)",
-        "line-width": {
-          "base": 1.8,
-          "stops": [
-            [
-              10,
-              3
-            ],
-            [
-              20,
-              60
-            ]
-          ]
-        }
+        "line-width": {"base": 1.8, "stops": [[10, 3], [20, 60]]}
       }
     },
     {
@@ -1093,33 +521,12 @@
       "maxzoom": 24,
       "filter": [
         "any",
-        [
-          "in",
-          "kind",
-          "residential",
-          "living_street",
-          "pedestrian"
-        ]
+        ["in", "kind", "residential", "living_street", "pedestrian"]
       ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
         "line-color": "rgba(112, 112, 112, 1)",
-        "line-width": {
-          "base": 1.55,
-          "stops": [
-            [
-              5,
-              1
-            ],
-            [
-              20,
-              30
-            ]
-          ]
-        }
+        "line-width": {"base": 1.55, "stops": [[5, 1], [20, 30]]}
       }
     },
     {
@@ -1129,33 +536,11 @@
       "source-layer": "roads",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": [
-        "any",
-        [
-          "in",
-          "kind",
-          "unclassified"
-        ]
-      ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "filter": ["any", ["in", "kind", "unclassified"]],
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
         "line-color": "rgba(112, 112, 112, 1)",
-        "line-width": {
-          "base": 1.55,
-          "stops": [
-            [
-              5,
-              1
-            ],
-            [
-              20,
-              30
-            ]
-          ]
-        }
+        "line-width": {"base": 1.55, "stops": [[5, 1], [20, 30]]}
       }
     },
     {
@@ -1165,37 +550,13 @@
       "source-layer": "roads",
       "filter": [
         "all",
-        [
-          "in",
-          "kind",
-          "tertiary",
-          "tertiary_link"
-        ],
-        [
-          "==",
-          "surface",
-          "unpaved"
-        ]
+        ["in", "kind", "tertiary", "tertiary_link"],
+        ["==", "surface", "unpaved"]
       ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
         "line-color": "rgba(100, 100, 0, 1)",
-        "line-width": {
-          "base": 1.55,
-          "stops": [
-            [
-              5,
-              2
-            ],
-            [
-              20,
-              25
-            ]
-          ]
-        }
+        "line-width": {"base": 1.55, "stops": [[5, 2], [20, 25]]}
       }
     },
     {
@@ -1205,37 +566,13 @@
       "source-layer": "roads",
       "filter": [
         "all",
-        [
-          "in",
-          "kind",
-          "tertiary",
-          "tertiary_link"
-        ],
-        [
-          "==",
-          "surface",
-          "paved"
-        ]
+        ["in", "kind", "tertiary", "tertiary_link"],
+        ["==", "surface", "paved"]
       ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
         "line-color": "#111111",
-        "line-width": {
-          "base": 1.55,
-          "stops": [
-            [
-              5,
-              2
-            ],
-            [
-              20,
-              25
-            ]
-          ]
-        }
+        "line-width": {"base": 1.55, "stops": [[5, 2], [20, 25]]}
       }
     },
     {
@@ -1243,34 +580,11 @@
       "type": "line",
       "source": "tilezen",
       "source-layer": "roads",
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "secondary",
-          "secondary_link"
-        ]
-      ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "filter": ["all", ["in", "kind", "secondary", "secondary_link"]],
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
         "line-color": "#111111",
-        "line-width": {
-          "base": 1.55,
-          "stops": [
-            [
-              5,
-              1.5
-            ],
-            [
-              20,
-              40
-            ]
-          ]
-        }
+        "line-width": {"base": 1.55, "stops": [[5, 1.5], [20, 40]]}
       }
     },
     {
@@ -1281,34 +595,12 @@
       "minzoom": 0,
       "filter": [
         "all",
-        [
-          "in",
-          "kind",
-          "primary",
-          "primary_link",
-          "secondary",
-          "secondary_link"
-        ]
+        ["in", "kind", "primary", "primary_link", "secondary", "secondary_link"]
       ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "butt"
-      },
+      "layout": {"line-join": "round", "line-cap": "butt"},
       "paint": {
         "line-color": "#111111",
-        "line-width": {
-          "base": 1.55,
-          "stops": [
-            [
-              5,
-              1.5
-            ],
-            [
-              20,
-              40
-            ]
-          ]
-        }
+        "line-width": {"base": 1.55, "stops": [[5, 1.5], [20, 40]]}
       }
     },
     {
@@ -1318,34 +610,12 @@
       "source-layer": "roads",
       "filter": [
         "all",
-        [
-          "in",
-          "kind",
-          "motorway",
-          "motorway_link",
-          "trunk",
-          "trunk_link"
-        ]
+        ["in", "kind", "motorway", "motorway_link", "trunk", "trunk_link"]
       ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
         "line-color": "#111111",
-        "line-width": {
-          "base": 1.55,
-          "stops": [
-            [
-              5,
-              2.3
-            ],
-            [
-              20,
-              40
-            ]
-          ]
-        }
+        "line-width": {"base": 1.55, "stops": [[5, 2.3], [20, 40]]}
       }
     },
     {
@@ -1355,79 +625,30 @@
       "source-layer": "landuse",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "runway",
-          "apron"
-        ]
-      ],
+      "filter": ["all", ["in", "kind", "runway", "apron"]],
       "layout": {},
-      "paint": {
-        "fill-color": "rgba(96, 96, 96, 1)"
-      }
+      "paint": {"fill-color": "rgba(96, 96, 96, 1)"}
     },
     {
       "id": "aeroway-apron",
       "type": "line",
       "source": "tilezen",
       "source-layer": "roads",
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "taxiway",
-          "parking_position"
-        ]
-      ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
-      "paint": {
-        "line-color": "rgba(120, 120, 120, 1)",
-        "line-width": 1
-      }
+      "filter": ["all", ["in", "kind", "taxiway", "parking_position"]],
+      "layout": {"line-join": "round", "line-cap": "round"},
+      "paint": {"line-color": "rgba(120, 120, 120, 1)", "line-width": 1}
     },
     {
       "id": "aeroway-runway",
       "type": "line",
       "source": "tilezen",
       "source-layer": "roads",
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "runway"
-        ]
-      ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "filter": ["all", ["in", "kind", "runway"]],
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
         "line-color": "rgba(220, 220, 220, 1)",
-        "line-width": {
-          "base": 1.55,
-          "stops": [
-            [
-              10,
-              1
-            ],
-            [
-              18,
-              10
-            ]
-          ]
-        },
-        "line-dasharray": [
-          2,
-          6
-        ]
+        "line-width": {"base": 1.55, "stops": [[10, 1], [18, 10]]},
+        "line-dasharray": [2, 6]
       }
     },
     {
@@ -1435,33 +656,11 @@
       "type": "line",
       "source": "tilezen",
       "source-layer": "roads",
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "service"
-        ]
-      ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "filter": ["all", ["in", "kind", "service"]],
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
         "line-color": "#110f0d",
-        "line-width": {
-          "base": 1.55,
-          "stops": [
-            [
-              8,
-              0.5
-            ],
-            [
-              20,
-              1
-            ]
-          ]
-        }
+        "line-width": {"base": 1.55, "stops": [[8, 0.5], [20, 1]]}
       }
     },
     {
@@ -1471,40 +670,12 @@
       "source-layer": "roads",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "path",
-          "footway",
-          "steps",
-          "cycleway"
-        ]
-      ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "filter": ["all", ["in", "kind", "path", "footway", "steps", "cycleway"]],
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
         "line-color": "#5d6765",
-        "line-width": {
-          "base": 1.8,
-          "stops": [
-            [
-              10,
-              0.5
-            ],
-            [
-              20,
-              3
-            ]
-          ]
-        },
-        "line-dasharray": [
-          10,
-          10
-        ]
+        "line-width": {"base": 1.8, "stops": [[10, 0.5], [20, 3]]},
+        "line-dasharray": [10, 10]
       }
     },
     {
@@ -1516,37 +687,13 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "in",
-          "kind",
-          "track"
-        ],
-        [
-          "in",
-          "tracktype",
-          "grade1",
-          "grade2"
-        ]
+        ["in", "kind", "track"],
+        ["in", "tracktype", "grade1", "grade2"]
       ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
         "line-color": "#110f0d",
-        "line-width": {
-          "base": 1.8,
-          "stops": [
-            [
-              10,
-              0.3
-            ],
-            [
-              20,
-              15
-            ]
-          ]
-        }
+        "line-width": {"base": 1.8, "stops": [[10, 0.3], [20, 15]]}
       }
     },
     {
@@ -1558,41 +705,14 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "in",
-          "kind",
-          "track"
-        ],
-        [
-          "!in",
-          "tracktype",
-          "grade1",
-          "grade2"
-        ]
+        ["in", "kind", "track"],
+        ["!in", "tracktype", "grade1", "grade2"]
       ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
         "line-color": "#110f0d",
-        "line-width": {
-          "base": 1.8,
-          "stops": [
-            [
-              10,
-              0.3
-            ],
-            [
-              20,
-              15
-            ]
-          ]
-        },
-        "line-dasharray": [
-          30,
-          7
-        ]
+        "line-width": {"base": 1.8, "stops": [[10, 0.3], [20, 15]]},
+        "line-dasharray": [30, 7]
       }
     },
     {
@@ -1604,33 +724,12 @@
       "maxzoom": 13,
       "filter": [
         "any",
-        [
-          "in",
-          "kind",
-          "residential",
-          "unclassified",
-          "living_street"
-        ]
+        ["in", "kind", "residential", "unclassified", "living_street"]
       ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
         "line-color": "rgba(170, 170, 170, 1)",
-        "line-width": {
-          "base": 1.55,
-          "stops": [
-            [
-              4,
-              0.25
-            ],
-            [
-              20,
-              30
-            ]
-          ]
-        }
+        "line-width": {"base": 1.55, "stops": [[4, 0.25], [20, 30]]}
       }
     },
     {
@@ -1641,33 +740,12 @@
       "minzoom": 13,
       "filter": [
         "any",
-        [
-          "in",
-          "kind",
-          "residential",
-          "living_street",
-          "pedestrian"
-        ]
+        ["in", "kind", "residential", "living_street", "pedestrian"]
       ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
         "line-color": "rgba(238, 238, 238, 1)",
-        "line-width": {
-          "base": 1.55,
-          "stops": [
-            [
-              4,
-              0.25
-            ],
-            [
-              20,
-              30
-            ]
-          ]
-        }
+        "line-width": {"base": 1.55, "stops": [[4, 0.25], [20, 30]]}
       }
     },
     {
@@ -1676,33 +754,11 @@
       "source": "tilezen",
       "source-layer": "roads",
       "minzoom": 13,
-      "filter": [
-        "any",
-        [
-          "in",
-          "kind",
-          "unclassified"
-        ]
-      ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "filter": ["any", ["in", "kind", "unclassified"]],
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
         "line-color": "#fffbb3",
-        "line-width": {
-          "base": 1.55,
-          "stops": [
-            [
-              4,
-              0.25
-            ],
-            [
-              20,
-              30
-            ]
-          ]
-        }
+        "line-width": {"base": 1.55, "stops": [[4, 0.25], [20, 30]]}
       }
     },
     {
@@ -1712,37 +768,13 @@
       "source-layer": "roads",
       "filter": [
         "all",
-        [
-          "in",
-          "kind",
-          "tertiary",
-          "tertiary_link"
-        ],
-        [
-          "==",
-          "surface",
-          "paved"
-        ]
+        ["in", "kind", "tertiary", "tertiary_link"],
+        ["==", "surface", "paved"]
       ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
         "line-color": "#d7b7ad",
-        "line-width": {
-          "base": 1.55,
-          "stops": [
-            [
-              5,
-              1
-            ],
-            [
-              20,
-              20
-            ]
-          ]
-        }
+        "line-width": {"base": 1.55, "stops": [[5, 1], [20, 20]]}
       }
     },
     {
@@ -1752,37 +784,13 @@
       "source-layer": "roads",
       "filter": [
         "all",
-        [
-          "in",
-          "kind",
-          "tertiary",
-          "tertiary_link"
-        ],
-        [
-          "==",
-          "surface",
-          "unpaved"
-        ]
+        ["in", "kind", "tertiary", "tertiary_link"],
+        ["==", "surface", "unpaved"]
       ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
         "line-color": "rgba(230, 220, 0, 1)",
-        "line-width": {
-          "base": 1.55,
-          "stops": [
-            [
-              5,
-              1
-            ],
-            [
-              20,
-              20
-            ]
-          ]
-        }
+        "line-width": {"base": 1.55, "stops": [[5, 1], [20, 20]]}
       }
     },
     {
@@ -1790,34 +798,11 @@
       "type": "line",
       "source": "tilezen",
       "source-layer": "roads",
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "secondary",
-          "secondary_link"
-        ]
-      ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "filter": ["all", ["in", "kind", "secondary", "secondary_link"]],
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
         "line-color": "#d7b7ad",
-        "line-width": {
-          "base": 1.55,
-          "stops": [
-            [
-              5,
-              1
-            ],
-            [
-              20,
-              34
-            ]
-          ]
-        }
+        "line-width": {"base": 1.55, "stops": [[5, 1], [20, 34]]}
       }
     },
     {
@@ -1825,34 +810,11 @@
       "type": "line",
       "source": "tilezen",
       "source-layer": "roads",
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "primary",
-          "primary_link"
-        ]
-      ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "butt"
-      },
+      "filter": ["all", ["in", "kind", "primary", "primary_link"]],
+      "layout": {"line-join": "round", "line-cap": "butt"},
       "paint": {
         "line-color": "#882a30",
-        "line-width": {
-          "base": 1.55,
-          "stops": [
-            [
-              5,
-              1
-            ],
-            [
-              20,
-              34
-            ]
-          ]
-        }
+        "line-width": {"base": 1.55, "stops": [[5, 1], [20, 34]]}
       }
     },
     {
@@ -1862,34 +824,12 @@
       "source-layer": "roads",
       "filter": [
         "all",
-        [
-          "in",
-          "kind",
-          "motorway",
-          "motorway_link",
-          "trunk",
-          "trunk_link"
-        ]
+        ["in", "kind", "motorway", "motorway_link", "trunk", "trunk_link"]
       ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
         "line-color": "#882a30",
-        "line-width": {
-          "base": 1.55,
-          "stops": [
-            [
-              5,
-              2
-            ],
-            [
-              20,
-              34
-            ]
-          ]
-        }
+        "line-width": {"base": 1.55, "stops": [[5, 2], [20, 34]]}
       }
     },
     {
@@ -1899,16 +839,23 @@
       "source-layer": "routes",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all"
-      ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "filter": ["all"],
+      "layout": {"line-join": "round", "line-cap": "round"},
+      "paint": {"line-color": "rgba(141, 36, 119, 0.3)", "line-width": 8}
+    },
+    {
+      "id": "railway-minor-casing",
+      "type": "line",
+      "source": "tilezen",
+      "source-layer": "roads",
+      "minzoom": 9,
+      "maxzoom": 24,
+      "filter": ["all", ["in", "kind", "yard", "spur", "siding", "crossover"]],
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
-        "line-color": "rgba(141, 36, 119, 0.3)",
-        "line-width": 8
+        "line-color": "rgba(100, 100, 100, 1)",
+        "line-width": {"base": 1.8, "stops": [[9, 1], [20, 7]]},
+        "line-dasharray": [2, 0]
       }
     },
     {
@@ -1918,37 +865,31 @@
       "source-layer": "roads",
       "minzoom": 9,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "rail"
-        ]
-      ],
-      "layout": {
-        "line-join": "round",
-        "line-cap": "round"
-      },
+      "filter": ["all", ["in", "kind", "rail"]],
+      "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
         "line-color": "rgba(100, 100, 100, 1)",
-        "line-width": {
-          "base": 1.8,
-          "stops": [
-            [
-              9,
-              2
-            ],
-            [
-              20,
-              15
-            ]
-          ]
-        },
-        "line-dasharray": [
-          2,
-          0
-        ]
+        "line-width": {"base": 1.8, "stops": [[9, 2], [20, 15]]},
+        "line-dasharray": [2, 0]
+      }
+    },
+    {
+      "id": "railway-minor",
+      "type": "line",
+      "source": "tilezen",
+      "source-layer": "roads",
+      "minzoom": 9,
+      "maxzoom": 24,
+      "filter": ["all", ["in", "kind", "yard", "spur", "siding", "crossover"]],
+      "layout": {
+        "line-join": "bevel",
+        "line-cap": "butt",
+        "visibility": "visible"
+      },
+      "paint": {
+        "line-color": "rgba(255, 255, 255, 1)",
+        "line-width": {"base": 1.8, "stops": [[9, 0.8], [20, 6]]},
+        "line-dasharray": [3, 4]
       }
     },
     {
@@ -1958,37 +899,12 @@
       "source-layer": "roads",
       "minzoom": 9,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "rail"
-        ]
-      ],
-      "layout": {
-        "line-join": "bevel",
-        "line-cap": "butt"
-      },
+      "filter": ["all", ["in", "kind", "rail"]],
+      "layout": {"line-join": "bevel", "line-cap": "butt"},
       "paint": {
         "line-color": "rgba(255, 255, 255, 1)",
-        "line-width": {
-          "base": 1.8,
-          "stops": [
-            [
-              9,
-              1.5
-            ],
-            [
-              20,
-              12
-            ]
-          ]
-        },
-        "line-dasharray": [
-          3,
-          4
-        ]
+        "line-width": {"base": 1.8, "stops": [[9, 1.5], [20, 12]]},
+        "line-dasharray": [3, 4]
       }
     },
     {
@@ -1996,43 +912,26 @@
       "type": "line",
       "source": "detail",
       "source-layer": "power_l",
-      "paint": {
-        "line-width": 0.4,
-        "line-color": "#666666"
-      }
+      "paint": {"line-width": 0.4, "line-color": "#666666"}
     },
     {
       "id": "power-p",
       "type": "circle",
       "source": "detail",
       "source-layer": "power_p",
-      "paint": {
-        "circle-radius": 2,
-        "circle-color": "#666666"
-      }
+      "paint": {"circle-radius": 2, "circle-color": "#666666"}
     },
     {
       "id": "power-l-label",
       "type": "symbol",
       "source": "detail",
       "source-layer": "power_l",
-      "filter": [
-        "all",
-        [
-          "has",
-          "voltage"
-        ]
-      ],
+      "filter": ["all", ["has", "voltage"]],
       "layout": {
-        "text-font": [
-          "Roboto Regular"
-        ],
+        "text-font": ["Roboto Regular"],
         "text-field": "{voltage} kV",
         "text-size": 10,
-        "text-offset": [
-          0,
-          -0.5
-        ],
+        "text-offset": [0, -0.5],
         "symbol-placement": "line"
       },
       "paint": {}
@@ -2049,14 +948,9 @@
         "text-size": 12,
         "text-max-width": 9,
         "text-anchor": "top",
-        "text-offset": [
-          0,
-          0.6
-        ],
+        "text-offset": [0, 0.6],
         "icon-image": "park",
-        "text-font": [
-          "Roboto Condensed Italic"
-        ],
+        "text-font": ["Roboto Condensed Italic"],
         "text-padding": 1
       },
       "paint": {
@@ -2074,22 +968,9 @@
       "maxzoom": 11,
       "filter": [
         "all",
-        [
-          "in",
-          "kind",
-          "motorway",
-          "trunk",
-          "primary"
-        ],
-        [
-          "has",
-          "ref"
-        ],
-        [
-          "<=",
-          "ref_length",
-          3
-        ]
+        ["in", "kind", "motorway", "trunk", "primary"],
+        ["has", "ref"],
+        ["<=", "ref_length", 3]
       ],
       "layout": {
         "text-field": "{ref}",
@@ -2098,9 +979,7 @@
         "text-anchor": "center",
         "text-size": 9,
         "text-allow-overlap": false,
-        "text-font": [
-          "Roboto Regular"
-        ],
+        "text-font": ["Roboto Regular"],
         "icon-image": "",
         "text-padding": 30,
         "symbol-avoid-edges": false
@@ -2120,24 +999,9 @@
       "maxzoom": 20,
       "filter": [
         "all",
-        [
-          "in",
-          "kind",
-          "motorway",
-          "trunk",
-          "primary",
-          "secondary",
-          "tertiary"
-        ],
-        [
-          "has",
-          "ref"
-        ],
-        [
-          "<=",
-          "ref_length",
-          5
-        ]
+        ["in", "kind", "motorway", "trunk", "primary", "secondary", "tertiary"],
+        ["has", "ref"],
+        ["<=", "ref_length", 5]
       ],
       "layout": {
         "text-field": "{ref}",
@@ -2146,9 +1010,7 @@
         "text-anchor": "center",
         "text-size": 9,
         "text-allow-overlap": true,
-        "text-font": [
-          "Roboto Regular"
-        ],
+        "text-font": ["Roboto Regular"],
         "icon-image": "",
         "text-padding": 30,
         "symbol-avoid-edges": false,
@@ -2167,23 +1029,16 @@
       "source-layer": "labels_c",
       "minzoom": 9,
       "maxzoom": 18,
-      "filter": [
-        "all"
-      ],
+      "filter": ["all"],
       "layout": {
         "symbol-placement": "line-center",
         "text-field": "{name}",
-        "text-font": [
-          "Playfair Italic"
-        ],
+        "text-font": ["Playfair Italic"],
         "text-letter-spacing": {
           "property": "letter_spacing",
           "type": "identity"
         },
-        "text-size": {
-          "property": "font_size",
-          "type": "identity"
-        },
+        "text-size": {"property": "font_size", "type": "identity"},
         "text-max-angle": 80
       },
       "paint": {
@@ -2200,18 +1055,11 @@
       "source-layer": "labels_p",
       "minzoom": 9,
       "maxzoom": 20,
-      "filter": [
-        "all"
-      ],
+      "filter": ["all"],
       "layout": {
         "text-field": "{name}",
-        "text-font": [
-          "Playfair Italic"
-        ],
-        "text-size": {
-          "property": "font_size",
-          "type": "identity"
-        },
+        "text-font": ["Playfair Italic"],
+        "text-size": {"property": "font_size", "type": "identity"},
         "text-letter-spacing": {
           "property": "letter_spacing",
           "type": "identity"
@@ -2232,19 +1080,10 @@
       "source-layer": "places",
       "minzoom": 14,
       "maxzoom": 16,
-      "filter": [
-        "any",
-        [
-          "==",
-          "kind",
-          "locality"
-        ]
-      ],
+      "filter": ["any", ["==", "kind", "locality"]],
       "layout": {
         "text-field": "{name}",
-        "text-font": [
-          "Playfair Regular"
-        ],
+        "text-font": ["Playfair Regular"],
         "text-max-width": 10,
         "text-letter-spacing": 0.1,
         "text-size": 11
@@ -2264,33 +1103,13 @@
       "source-layer": "places",
       "minzoom": 10,
       "maxzoom": 15,
-      "filter": [
-        "any",
-        [
-          "==",
-          "kind",
-          "hamlet"
-        ]
-      ],
+      "filter": ["any", ["==", "kind", "hamlet"]],
       "layout": {
         "text-field": "{name}",
-        "text-font": [
-          "Roboto Condensed Italic"
-        ],
+        "text-font": ["Roboto Condensed Italic"],
         "text-max-width": 10,
         "text-letter-spacing": 0.1,
-        "text-size": {
-          "stops": [
-            [
-              8,
-              8
-            ],
-            [
-              14,
-              13
-            ]
-          ]
-        }
+        "text-size": {"stops": [[8, 8], [14, 13]]}
       },
       "paint": {
         "text-color": "#384646",
@@ -2307,33 +1126,13 @@
       "source-layer": "places",
       "minzoom": 10,
       "maxzoom": 15,
-      "filter": [
-        "any",
-        [
-          "==",
-          "kind",
-          "village"
-        ]
-      ],
+      "filter": ["any", ["==", "kind", "village"]],
       "layout": {
         "text-field": "{name}",
-        "text-font": [
-          "Playfair Regular"
-        ],
+        "text-font": ["Playfair Regular"],
         "text-max-width": 10,
         "text-letter-spacing": 0.1,
-        "text-size": {
-          "stops": [
-            [
-              8,
-              8
-            ],
-            [
-              14,
-              13
-            ]
-          ]
-        },
+        "text-size": {"stops": [[8, 8], [14, 13]]},
         "symbol-spacing": 250,
         "text-padding": 5
       },
@@ -2354,33 +1153,14 @@
       "maxzoom": 13,
       "filter": [
         "all",
-        [
-          "in",
-          "kind",
-          "town",
-          "little_town",
-          "railway_station"
-        ]
+        ["in", "kind", "town", "little_town", "railway_station"]
       ],
       "layout": {
         "text-field": "{name}",
-        "text-font": [
-          "Playfair Regular"
-        ],
+        "text-font": ["Playfair Regular"],
         "text-max-width": 10,
         "text-letter-spacing": 0.1,
-        "text-size": {
-          "stops": [
-            [
-              8,
-              12
-            ],
-            [
-              12,
-              13
-            ]
-          ]
-        }
+        "text-size": {"stops": [[8, 12], [12, 13]]}
       },
       "paint": {
         "text-color": "#111111",
@@ -2395,20 +1175,10 @@
       "source-layer": "places",
       "minzoom": 12,
       "maxzoom": 16,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "suburb",
-          "neighbourhood"
-        ]
-      ],
+      "filter": ["all", ["in", "kind", "suburb", "neighbourhood"]],
       "layout": {
         "text-field": "{name}",
-        "text-font": [
-          "Playfair Regular"
-        ],
+        "text-font": ["Playfair Regular"],
         "text-max-width": 10,
         "text-letter-spacing": 0.05,
         "text-size": 15,
@@ -2427,19 +1197,10 @@
       "source-layer": "places",
       "minzoom": 7,
       "maxzoom": 14,
-      "filter": [
-        "all",
-        [
-          "in",
-          "kind",
-          "city"
-        ]
-      ],
+      "filter": ["all", ["in", "kind", "city"]],
       "layout": {
         "text-field": "{name}",
-        "text-font": [
-          "Playfair Regular"
-        ],
+        "text-font": ["Playfair Regular"],
         "text-max-width": 10,
         "text-letter-spacing": 0.1,
         "text-size": 18,
@@ -2458,26 +1219,12 @@
       "source-layer": "water",
       "minzoom": 8,
       "maxzoom": 18,
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "LineString"
-        ],
-        [
-          "==",
-          "virtual",
-          "N"
-        ]
-      ],
+      "filter": ["all", ["==", "$type", "LineString"], ["==", "virtual", "N"]],
       "layout": {
         "text-field": "{name}",
         "symbol-placement": "line",
         "text-rotation-alignment": "auto",
-        "text-font": [
-          "Playfair Italic"
-        ],
+        "text-font": ["Playfair Italic"],
         "text-padding": 5,
         "text-allow-overlap": false,
         "text-ignore-placement": false,
@@ -2497,35 +1244,15 @@
       "source-layer": "roads",
       "minzoom": 10,
       "maxzoom": 20,
-      "filter": [
-        "all",
-        [
-          "!=",
-          "kind",
-          "proposed"
-        ]
-      ],
+      "filter": ["all", ["!=", "kind", "proposed"]],
       "layout": {
         "text-field": "{name}",
         "symbol-placement": "line",
         "text-rotation-alignment": "auto",
         "text-anchor": "bottom",
-        "text-size": {
-          "stops": [
-            [
-              10,
-              8
-            ],
-            [
-              20,
-              16
-            ]
-          ]
-        },
+        "text-size": {"stops": [[10, 8], [20, 16]]},
         "text-allow-overlap": false,
-        "text-font": [
-          "Playfair Regular"
-        ],
+        "text-font": ["Playfair Regular"],
         "text-letter-spacing": 0.05
       },
       "paint": {
@@ -2547,9 +1274,7 @@
         "text-anchor": "bottom",
         "text-size": 12,
         "text-allow-overlap": false,
-        "text-font": [
-          "Roboto Condensed Italic"
-        ],
+        "text-font": ["Roboto Condensed Italic"],
         "text-letter-spacing": 0.1,
         "text-max-angle": 60
       },
@@ -2566,22 +1291,13 @@
       "source-layer": "names",
       "minzoom": 14,
       "maxzoom": 20,
-      "filter": [
-        "all",
-        [
-          "==",
-          "kind",
-          "cemetery"
-        ]
-      ],
+      "filter": ["all", ["==", "kind", "cemetery"]],
       "layout": {
         "text-field": "{name}",
         "text-size": 12,
         "text-max-width": 9,
         "text-anchor": "top",
-        "text-font": [
-          "Roboto Condensed Italic"
-        ],
+        "text-font": ["Roboto Condensed Italic"],
         "text-padding": 1
       },
       "paint": {
@@ -2596,9 +1312,7 @@
       "source": "topo",
       "source-layer": "topo_sym",
       "minzoom": 12,
-      "layout": {
-        "icon-image": "{kind}"
-      },
+      "layout": {"icon-image": "{kind}"},
       "paint": {
         "icon-halo-width": 2,
         "icon-halo-color": "rgba(255, 255, 255, 1)",


### PR DESCRIPTION
1. Topografiniame žemėlapyje pridėti pagalbiniai geležinkeliai (su _service=*_)
2. Pataisyta klaida, kai 14 mastelyje _landuse=railway_ nebuvo traukiamas kaip _kind=industrial_, dėl ko niekaip nebuvo vaizduojamas žemėlapyje.