### PR TITLE
Topo/upių stiliai: aikštelės ir pėsčiųjų takai

### DIFF
--- a/demo/styles/topo.json
+++ b/demo/styles/topo.json
@@ -288,7 +288,7 @@
       "source-layer": "detail_poly",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": ["all", ["==", "kind", "stadium"]],
+      "filter": ["all", ["in", "kind", "stadium", "pitch"]],
       "paint": {
         "line-width": 0.5,
         "line-dasharray": [12, 6],

--- a/demo/styles/topo.json
+++ b/demo/styles/topo.json
@@ -730,11 +730,11 @@
       "minzoom": 12,
       "maxzoom": 24,
       "filter": ["all", ["in", "kind", "path", "footway", "steps", "cycleway"]],
-      "layout": {"line-join": "round", "line-cap": "round"},
+      "layout": {"line-join": "round", "line-cap": "square"},
       "paint": {
         "line-color": "#5d6765",
-        "line-width": {"base": 1.8, "stops": [[10, 0.5], [20, 3]]},
-        "line-dasharray": [10, 10]
+        "line-width": {"base": 1.8, "stops": [[14, 1], [18, 2]]},
+        "line-dasharray": [1, 2]
       }
     },
     {

--- a/demo/styles/upes.json
+++ b/demo/styles/upes.json
@@ -322,7 +322,7 @@
       "source-layer": "detail_poly",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": ["all", ["in", "kind", "stadium", "pitch"]],
+      "filter": ["all", ["==", "kind", "stadium"]],
       "paint": {
         "line-width": 0.5,
         "line-dasharray": [12, 6],
@@ -781,11 +781,11 @@
       "minzoom": 12,
       "maxzoom": 24,
       "filter": ["all", ["in", "kind", "path", "footway", "steps", "cycleway"]],
-      "layout": {"line-join": "round", "line-cap": "round"},
+      "layout": {"line-join": "round", "line-cap": "square"},
       "paint": {
         "line-color": "#5d6765",
-        "line-width": {"base": 1.8, "stops": [[10, 0.5], [20, 3]]},
-        "line-dasharray": [10, 10]
+        "line-width": {"base": 1.8, "stops": [[14, 1], [18, 2]]},
+        "line-dasharray": [1, 2]
       }
     },
     {

--- a/demo/styles/upes.json
+++ b/demo/styles/upes.json
@@ -322,7 +322,7 @@
       "source-layer": "detail_poly",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": ["all", ["==", "kind", "stadium"]],
+      "filter": ["all", ["in", "kind", "stadium", "pitch"]],
       "paint": {
         "line-width": 0.5,
         "line-dasharray": [12, 6],


### PR DESCRIPTION
1. Nuo 16 mastelio rodyti ir _leisure=pitch_ (taip pat, kaip dabar jau rodomi _leisure=stadium_)
2. Pėsčiųjų takai braižomi taškiukais, brūkšniukai lieka išskirtinai tik automobiliais pravažiuojamiems keliams.
![paveikslas](https://user-images.githubusercontent.com/969513/71768242-16b8fa80-2f1d-11ea-856e-6fb6aed7e7be.png)
