### PR TITLE
Tunelių/tiltų duomenys, simbolių patikslinimai, perėjos

### DIFF
--- a/data/roads/z2a.pgsql
+++ b/data/roads/z2a.pgsql
@@ -28,6 +28,20 @@ SELECT
        ELSE null
   END AS tracktype,
   length(ref) AS ref_length,
+  (
+    CASE
+      WHEN tunnel IS NOT NULL
+        THEN 'yes'
+      ELSE null
+    END
+  ) as is_tunnel,
+  (
+    CASE
+      WHEN bridge IS NOT NULL
+        THEN 'yes'
+      ELSE null
+    END
+  ) as is_bridge,
   layer
 FROM
   planet_osm_line
@@ -48,5 +62,5 @@ WHERE
    OR (railway = 'rail' AND service IS NULL)
    OR aeroway IN ('runway', 'taxiway', 'parking_position')
   )
-GROUP BY kind, surface, name, priority, ref, highway, tracktype, layer
+GROUP BY kind, surface, name, priority, ref, highway, tracktype, is_tunnel, is_bridge, layer
 ORDER BY priority

--- a/data/roads/z2b.pgsql
+++ b/data/roads/z2b.pgsql
@@ -47,7 +47,7 @@ WHERE
                'path')
    OR (highway = 'service' AND service = 'long_distance')
    OR (highway = 'track' AND coalesce(track, '!@#') != 'driveway')
-   OR (highway = 'footway' AND coalesce(footway, '!@#') != 'sidewalk')
+   OR (highway = 'footway' AND coalesce(footway, '!@#') not in ('sidewalk', 'crossing'))
    OR (railway = 'rail' AND service IS NULL)
    OR aeroway IN ('runway', 'taxiway', 'parking_position')
   )

--- a/data/roads/z2b.pgsql
+++ b/data/roads/z2b.pgsql
@@ -28,6 +28,20 @@ SELECT
        ELSE null
   END AS tracktype,
   length(ref) AS ref_length,
+  (
+    CASE
+      WHEN tunnel IS NOT NULL
+        THEN 'yes'
+      ELSE null
+    END
+  ) as is_tunnel,
+  (
+    CASE
+      WHEN bridge IS NOT NULL
+        THEN 'yes'
+      ELSE null
+    END
+  ) as is_bridge,
   layer
 FROM
   planet_osm_line
@@ -51,5 +65,5 @@ WHERE
    OR (railway = 'rail' AND service IS NULL)
    OR aeroway IN ('runway', 'taxiway', 'parking_position')
   )
-GROUP BY kind, surface, name, priority, ref, highway, tracktype, layer
+GROUP BY kind, surface, name, priority, ref, highway, tracktype, is_tunnel, is_bridge, layer
 ORDER BY priority

--- a/data/roads/z3.pgsql
+++ b/data/roads/z3.pgsql
@@ -32,14 +32,14 @@ SELECT
     CASE
       WHEN tunnel IS NOT NULL
         THEN 'yes'
-      ELSE 'no'
+      ELSE null
     END
   ) as is_tunnel,
   (
     CASE
       WHEN bridge IS NOT NULL
         THEN 'yes'
-      ELSE 'no'
+      ELSE null
     END
   ) as is_bridge,
   coalesce(oneway, 'no') AS oneway,

--- a/demo/sprites/topo.json
+++ b/demo/sprites/topo.json
@@ -44,8 +44,8 @@
   "cliff": {
     "height": 9,
     "pixelRatio": 1,
-    "width": 15,
-    "x": 219,
+    "width": 12,
+    "x": 220,
     "y": 148
   },
   "communication_tower": {
@@ -142,8 +142,8 @@
   "rapids": {
     "height": 11,
     "pixelRatio": 1,
-    "width": 25,
-    "x": 90,
+    "width": 20,
+    "x": 93,
     "y": 148
   },
   "reedbed": {

--- a/demo/sprites/topo@2x.json
+++ b/demo/sprites/topo@2x.json
@@ -44,8 +44,8 @@
   "cliff": {
     "height": 18,
     "pixelRatio": 2,
-    "width": 30,
-    "x": 438,
+    "width": 24,
+    "x": 440,
     "y": 296
   },
   "communication_tower": {
@@ -142,8 +142,8 @@
   "rapids": {
     "height": 22,
     "pixelRatio": 2,
-    "width": 50,
-    "x": 180,
+    "width": 40,
+    "x": 186,
     "y": 296
   },
   "reedbed": {


### PR DESCRIPTION
1. 13-18 mastelio kaladėlėse pridedami tiltų/tunelių požymiai, bet tik kai reikšmė „yes“.
2. Perėjos (_footway=crossing_) smulkesniuose masteliuose net nededamos į kaladėles, kaip ir šaligatviai (_footway=sidewalk_).
3. Sutvarkyti skardžio ir slenksčio simboliai topo žemėlapyje.