### PR TITLE
Topo nerodyti statomų kelių etikečių

### DIFF
--- a/demo/styles/topo.json
+++ b/demo/styles/topo.json
@@ -1591,7 +1591,7 @@
       "source-layer": "roads",
       "minzoom": 10,
       "maxzoom": 20,
-      "filter": ["all", ["!=", "kind", "proposed"]],
+      "filter": ["all", ["!in", "kind", "proposed", "construction"]],
       "layout": {
         "text-field": "{name}",
         "symbol-placement": "line",


### PR DESCRIPTION
Topografiniame žemėlapyje (kol kas) nerodomi statomi keliai, todėl nereikia rodyti ir jų etikečių.