### PR TITLE
Greičio žemėlapis: švelnesnės spalvos ir 20km living_street

### DIFF
--- a/config.toml.template
+++ b/config.toml.template
@@ -856,7 +856,7 @@ center = [23.871, 55.191, 7.0]
   [[maps.layers]]
   name = "speed"
   provider_layer = "osm.speed13"
-  min_zoom = 12
+  min_zoom = 11
   max_zoom = 13
 
   [[maps.layers]]

--- a/data/speed/z13.sql
+++ b/data/speed/z13.sql
@@ -1,7 +1,7 @@
 SELECT
   row_number() over() AS gid,
   st_asbinary(st_linemerge(st_collect(way))) AS geom,
-  maxspeed,
+  case when highway = 'living_street' then coalesce(maxspeed, '20') else maxspeed end as maxspeed,
   "maxspeed:forward" as forward,
   "maxspeed:backward" as backward
 FROM
@@ -22,6 +22,7 @@ WHERE
   ) AND
   (maxspeed is not null or
    "maxspeed:forward" is not null or
-   "maxspeed:backward" is not null
+   "maxspeed:backward" is not null or
+   highway = 'living_street'
   )
-GROUP BY "maxspeed:forward", "maxspeed:backward", maxspeed
+GROUP BY "maxspeed:forward", "maxspeed:backward", maxspeed, highway

--- a/data/speed/z14.sql
+++ b/data/speed/z14.sql
@@ -1,7 +1,7 @@
 SELECT
   row_number() over() AS gid,
   st_asbinary(st_linemerge(st_collect(way))) AS geom,
-  maxspeed,
+  case when highway = 'living_street' then coalesce(maxspeed, '20') else maxspeed end as maxspeed,
   "maxspeed:forward" as forward,
   "maxspeed:backward" as backward
 FROM
@@ -22,6 +22,7 @@ WHERE
   ) AND
   (maxspeed is not null or
    "maxspeed:forward" is not null or
-   "maxspeed:backward" is not null
+   "maxspeed:backward" is not null or
+   highway = 'living_street'
   )
-GROUP BY "maxspeed:forward", "maxspeed:backward", maxspeed
+GROUP BY "maxspeed:forward", "maxspeed:backward", maxspeed, highway

--- a/data/speed/z15.sql
+++ b/data/speed/z15.sql
@@ -1,7 +1,7 @@
 SELECT
   row_number() over() AS gid,
   st_asbinary(st_linemerge(st_collect(way))) AS geom,
-  maxspeed,
+  case when highway = 'living_street' then coalesce(maxspeed, '20') else maxspeed end as maxspeed,
   "maxspeed:forward" as forward,
   "maxspeed:backward" as backward
 FROM
@@ -22,6 +22,7 @@ WHERE
   ) AND
   (maxspeed is not null or
    "maxspeed:forward" is not null or
-   "maxspeed:backward" is not null
+   "maxspeed:backward" is not null or
+   highway = 'living_street'
   )
-GROUP BY "maxspeed:forward", "maxspeed:backward", maxspeed
+GROUP BY "maxspeed:forward", "maxspeed:backward", maxspeed, highway

--- a/demo/styles/speed.json
+++ b/demo/styles/speed.json
@@ -38,7 +38,10 @@
       "source": "tilezen",
       "source-layer": "coastline",
       "filter": ["==", "kind", "coastline"],
-      "paint": {"fill-color": "#bed7f0", "fill-outline-color": "#49a5dd"}
+      "paint": {
+        "fill-color": "rgba(194, 218, 242, 1)",
+        "fill-outline-color": "#49a5dd"
+      }
     },
     {
       "id": "landuse-forest",
@@ -47,7 +50,7 @@
       "source-layer": "landuse",
       "minzoom": 7,
       "filter": ["all", ["in", "kind", "forest"]],
-      "paint": {"fill-color": "#cbe3a9", "fill-opacity": 1}
+      "paint": {"fill-color": "rgba(218, 230, 186, 1)", "fill-opacity": 1}
     },
     {
       "id": "landuse-orchard-sym",
@@ -241,7 +244,7 @@
       "source-layer": "water",
       "filter": ["==", "$type", "Polygon"],
       "paint": {
-        "fill-color": "#bed7f0",
+        "fill-color": "rgba(194, 218, 242, 1)",
         "fill-outline-color": "#49a5dd",
         "fill-antialias": false
       }
@@ -298,7 +301,8 @@
         "line-width": 0.5,
         "line-dasharray": [12, 6],
         "line-translate": [0, 0],
-        "line-offset": 3
+        "line-offset": 3,
+        "line-color": "#333333"
       }
     },
     {
@@ -536,7 +540,7 @@
       "filter": ["all", ["==", "kind", "ruins"]],
       "paint": {
         "line-width": {"stops": [[14, 0.5], [16, 2]]},
-        "line-color": "#444444"
+        "line-color": "#999999"
       }
     },
     {
@@ -547,7 +551,7 @@
       "minzoom": 12,
       "maxzoom": 20,
       "filter": ["all", ["!=", "kind", "ruins"]],
-      "paint": {"fill-color": "#444444"}
+      "paint": {"fill-color": "#999999"}
     },
     {
       "id": "road-track-bkg",
@@ -1012,7 +1016,7 @@
       ],
       "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
-        "line-color": "#882a30",
+        "line-color": "rgba(153, 107, 111, 1)",
         "line-width": {"base": 1.55, "stops": [[5, 2], [20, 34]]}
       }
     },
@@ -1048,7 +1052,7 @@
       ],
       "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
-        "line-color": "rgba(230, 220, 0, 1)",
+        "line-color": "rgba(230, 225, 114, 1)",
         "line-width": {"base": 1.55, "stops": [[5, 1], [20, 20]]}
       }
     },
@@ -1082,7 +1086,7 @@
       ],
       "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
-        "line-color": "#882a30",
+        "line-color": "rgba(153, 107, 111, 1)",
         "line-width": {"base": 1.55, "stops": [[5, 1], [20, 34]]}
       }
     },
@@ -1099,7 +1103,7 @@
       ],
       "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
-        "line-color": "#882a30",
+        "line-color": "rgba(153, 107, 111, 1)",
         "line-width": {"base": 1.55, "stops": [[5, 2], [20, 34]]}
       }
     },
@@ -1244,7 +1248,7 @@
       ],
       "layout": {"line-join": "round", "line-cap": "square"},
       "paint": {
-        "line-color": "#882a30",
+        "line-color": "rgba(153, 107, 111, 1)",
         "line-width": {"base": 1.55, "stops": [[5, 0.8], [20, 32]]}
       }
     },
@@ -1261,7 +1265,7 @@
       ],
       "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
-        "line-color": "rgba(136, 42, 48, 1)",
+        "line-color": "rgba(153, 107, 111, 1)",
         "line-width": {"base": 1.55, "stops": [[5, 1.5], [20, 25]]}
       }
     },
@@ -1324,7 +1328,7 @@
       ],
       "layout": {"line-join": "round", "line-cap": "butt"},
       "paint": {
-        "line-color": "#882a30",
+        "line-color": "rgba(153, 107, 111, 1)",
         "line-width": {"base": 1.55, "stops": [[5, 0.8], [20, 20]]}
       }
     },
@@ -1341,7 +1345,7 @@
       ],
       "layout": {"line-join": "round", "line-cap": "round"},
       "paint": {
-        "line-color": "#882a30",
+        "line-color": "rgba(153, 107, 111, 1)",
         "line-width": {"base": 1.55, "stops": [[5, 1.5], [20, 25]]}
       }
     },
@@ -1414,14 +1418,14 @@
       "type": "line",
       "source": "detail",
       "source-layer": "power_l",
-      "paint": {"line-width": 0.4, "line-color": "#666666"}
+      "paint": {"line-width": 0.4, "line-color": "#888888"}
     },
     {
       "id": "power-p",
       "type": "circle",
       "source": "detail",
       "source-layer": "power_p",
-      "paint": {"circle-radius": 2, "circle-color": "#666666"}
+      "paint": {"circle-radius": 2, "circle-color": "#888888"}
     },
     {
       "id": "power-l-label",
@@ -1436,7 +1440,7 @@
         "text-offset": [0, -0.5],
         "symbol-placement": "line"
       },
-      "paint": {}
+      "paint": {"text-color": "rgba(102, 102, 102, 1)"}
     },
     {
       "id": "label-park",
@@ -1874,7 +1878,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "maxspeed", "130"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(94, 79, 162, 0.6)"
       }
     },
@@ -1885,7 +1889,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "maxspeed", "120"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(50, 136, 189, 0.6)"
       }
     },
@@ -1896,7 +1900,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "maxspeed", "110"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(102, 194, 165, 0.6)"
       }
     },
@@ -1907,7 +1911,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "maxspeed", "100"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(171, 221, 164, 0.6)"
       }
     },
@@ -1918,7 +1922,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "maxspeed", "LT:rural"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(230, 245, 152, 0.6)",
         "line-dasharray": [2, 2]
       }
@@ -1931,9 +1935,9 @@
       "filter": ["all", ["==", "backward", "90"]],
       "layout": {"visibility": "visible"},
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(230, 245, 152, 0.6)",
-        "line-offset": {"stops": [[12, -2], [14, -5]]}
+        "line-offset": {"stops": [[11, -2], [14, -5]]}
       }
     },
     {
@@ -1944,7 +1948,7 @@
       "filter": ["all", ["==", "forward", "90"]],
       "layout": {"visibility": "visible"},
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(230, 245, 152, 0.6)",
         "line-offset": {"stops": [[12, 2], [14, 5]]}
       }
@@ -1956,7 +1960,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "maxspeed", "90"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(230, 245, 152, 0.8)"
       }
     },
@@ -1967,7 +1971,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "maxspeed", "80"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(254, 224, 139, 0.8)"
       }
     },
@@ -1978,7 +1982,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "forward", "70"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(253, 174, 97, 0.8)",
         "line-offset": {"stops": [[12, 2], [14, 5]]}
       }
@@ -1990,7 +1994,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "backward", "70"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(253, 174, 97, 0.8)",
         "line-offset": {"stops": [[12, -2], [14, -5]]}
       }
@@ -2002,7 +2006,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "maxspeed", "70"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(253, 174, 97, 0.8)"
       }
     },
@@ -2013,7 +2017,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "backward", "60"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(244, 109, 67, 0.6)",
         "line-offset": {"stops": [[12, -2], [14, -5]]}
       }
@@ -2025,7 +2029,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "forward", "60"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(244, 109, 67, 0.6)",
         "line-offset": {"stops": [[12, 2], [14, 5]]}
       }
@@ -2037,7 +2041,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "maxspeed", "60"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(244, 109, 67, 0.6)"
       }
     },
@@ -2048,7 +2052,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "maxspeed", "LT:urban"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(213, 62, 79, 0.6)",
         "line-dasharray": [2, 2]
       }
@@ -2060,7 +2064,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "backward", "50"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(213, 62, 79, 0.6)",
         "line-offset": {"stops": [[12, -2], [14, -5]]}
       }
@@ -2072,7 +2076,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "forward", "50"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(213, 62, 79, 0.6)",
         "line-offset": {"stops": [[12, 2], [14, 5]]}
       }
@@ -2084,7 +2088,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "maxspeed", "50"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(213, 62, 79, 0.6)"
       }
     },
@@ -2095,7 +2099,7 @@
       "source-layer": "speed",
       "filter": ["all", ["in", "maxspeed", "40", "30", "20"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(158, 1, 66, 0.6)"
       }
     },

--- a/demo/styles/speed_hybrid.json
+++ b/demo/styles/speed_hybrid.json
@@ -519,7 +519,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "maxspeed", "130"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(94, 79, 162, 0.6)"
       }
     },
@@ -530,7 +530,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "maxspeed", "120"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(50, 136, 189, 0.6)"
       }
     },
@@ -541,7 +541,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "maxspeed", "110"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(102, 194, 165, 0.6)"
       }
     },
@@ -552,7 +552,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "maxspeed", "100"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(171, 221, 164, 0.6)"
       }
     },
@@ -563,7 +563,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "maxspeed", "LT:rural"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(230, 245, 152, 0.6)",
         "line-dasharray": [2, 2]
       }
@@ -576,7 +576,7 @@
       "filter": ["all", ["==", "backward", "90"]],
       "layout": {"visibility": "visible"},
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(230, 245, 152, 0.6)",
         "line-offset": {"stops": [[12, -2], [14, -5]]}
       }
@@ -589,7 +589,7 @@
       "filter": ["all", ["==", "forward", "90"]],
       "layout": {"visibility": "visible"},
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(230, 245, 152, 0.6)",
         "line-offset": {"stops": [[12, 2], [14, 5]]}
       }
@@ -601,7 +601,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "maxspeed", "90"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(230, 245, 152, 0.6)"
       }
     },
@@ -612,7 +612,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "maxspeed", "80"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(254, 224, 139, 0.6)"
       }
     },
@@ -623,7 +623,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "forward", "70"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(253, 174, 97, 0.8)",
         "line-offset": {"stops": [[12, 2], [14, 5]]}
       }
@@ -635,7 +635,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "backward", "70"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(253, 174, 97, 0.8)",
         "line-offset": {"stops": [[12, -2], [14, -5]]}
       }
@@ -647,7 +647,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "maxspeed", "70"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(253, 174, 97, 0.6)"
       }
     },
@@ -658,7 +658,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "backward", "60"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(244, 109, 67, 0.6)",
         "line-offset": {"stops": [[12, -2], [14, -5]]}
       }
@@ -670,7 +670,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "forward", "60"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(244, 109, 67, 0.6)",
         "line-offset": {"stops": [[12, 2], [14, 5]]}
       }
@@ -682,7 +682,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "maxspeed", "60"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(244, 109, 67, 0.6)"
       }
     },
@@ -693,7 +693,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "maxspeed", "LT:urban"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(213, 62, 79, 0.6)",
         "line-dasharray": [2, 2]
       }
@@ -705,7 +705,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "backward", "50"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(213, 62, 79, 0.6)",
         "line-offset": {"stops": [[12, -2], [14, -5]]}
       }
@@ -717,7 +717,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "forward", "50"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(213, 62, 79, 0.6)",
         "line-offset": {"stops": [[12, 2], [14, 5]]}
       }
@@ -729,7 +729,7 @@
       "source-layer": "speed",
       "filter": ["all", ["==", "maxspeed", "50"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(213, 62, 79, 0.6)"
       }
     },
@@ -740,7 +740,7 @@
       "source-layer": "speed",
       "filter": ["all", ["in", "maxspeed", "40", "30", "20"]],
       "paint": {
-        "line-width": {"stops": [[12, 4], [14, 10]]},
+        "line-width": {"stops": [[11, 3], [14, 8]]},
         "line-color": "rgba(158, 1, 66, 0.6)"
       }
     },


### PR DESCRIPTION
1. Pašvelnintos žemėlapio pagrindo spalvos.
2. Greičio informacija rodoma nuo 11 mastelio.
3. Šiek tiek paplonintos greičio simbolizavimo linijos.
4. living_street gatvėms rodomas 20km/h greitis (jei nėra maxspeed žymos).