### PR TITLE
fix insecure cookie warning

### DIFF
--- a/demo/map.js
+++ b/demo/map.js
@@ -260,7 +260,7 @@ function storeCookie(name, value) {
   var date = new Date();
   date.setDate(date.getDate() + 365);
   var expires = "expires=" + date.toUTCString();
-  document.cookie = name + '=' + JSON.stringify(value) + ';domain=.' + window.location.host.toString() + ';path=/;' + expires;
+  document.cookie = name + '=' + JSON.stringify(value) + ';domain=.' + window.location.host.toString() + ';path=/;' + expires + ';secure;samesite=strict';
 }
 
 function readCookie(name) {


### PR DESCRIPTION
Fix warning
```
Cookie “mapData” will be soon rejected because it has the “sameSite” attribute set to “none” or an invalid value, without the “secure” attribute. To learn more about the “sameSite“ attribute, read https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite
```