### PR TITLE
Make README instructions "almost" work again

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -22,4 +22,5 @@ docker exec -u postgres $CONTAINER_DB sh -c 'psql osm -f /src/db/gen_building.sq
 docker exec -u postgres $CONTAINER_DB sh -c 'psql osm -f /src/db/gen_forest.sql'
 docker exec -u postgres $CONTAINER_DB sh -c 'psql osm -f /src/db/gen_protected.sql'
 
-#docker exec -u postgres $CONTAINER_DB sh -c 'bunzip2 -ck /src/queries/coastline/coastline.sql.bz2 | psql osm'
+docker exec -u postgres $CONTAINER_DB sh -c 'bzip2 -cd /src/data/coastline/coastline.sql.bz2 | psql osm'
+docker exec -u postgres -w /src/db/upiu_baseinai $CONTAINER_DB ./go.sh

--- a/db/upiu_baseinai/go.sh
+++ b/db/upiu_baseinai/go.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-psql osm -U osm < upiu_baseinai.sql
-psql osm -U osm < merge_water.sql
-psql osm -U osm < touch.sql
-psql osm -U osm < process.sql
-psql osm -U osm < process_plot.sql
+set -e
+psql osm < upiu_baseinai.sql
+psql osm < merge_water.sql
+psql osm < touch.sql
+psql osm < process.sql
+psql osm < process_plot.sql


### PR DESCRIPTION
When following the docker setup instructions in the README, Tegola fails
to start and emits these errors:

```
1. could not register providers: error fetching geometry type for layer (coastline7): ERROR: relation "coastline" does not exist (SQLSTATE 42P01)

2. could not register providers: error fetching geometry type for layer (basins7): ERROR: relation "upiu_baseinai" does not exist (SQLSTATE 42P01)
```

This diff fixes both. The proxy server does not start yet, but this will come in a different PR.