### PR TITLE
naudojame oficialų postgis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,12 +12,11 @@ services:
       - ".:/src"
 
   db:
-    image: kartoza/postgis:9.6-2.4
+    image: postgis/postgis:13-3.0
     environment:
       POSTGRES_DBNAME: osm
       POSTGRES_USER: osm
-      POSTGRES_PASS: osm
-      ALLOW_IP_RANGE: 172.17.0.0/8
+      POSTGRES_PASSWORD: osm
     volumes:
       - ".:/src"
       - "/var/lib/postgresql"


### PR DESCRIPTION
Dabartinis (iš `kartoza`) neteisingai naudoja `POSTGRES_*` parametrus. Kitaip tariant, man lengvai nepavyko padaryti, kad authn veiktų be priekaištų su `osm` vartotoju.