### PR TITLE
suvienodinti init.sh ir go.sh

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -1,26 +1,47 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 if [ ! -e data.pbf ]; then
 	wget -O data.pbf http://download.geofabrik.de/europe/lithuania-latest.osm.pbf
 fi
 
-CONTAINER_DB=`docker-compose ps -q db`
+CONTAINER_DB=$(docker-compose ps -q db)
 # install shp2pgsql
-docker exec $CONTAINER_DB sh -c 'apt update -qy && apt install -qy postgis'
+docker exec "$CONTAINER_DB" sh -c 'apt update -qy && apt install -qy postgis'
 
 # load data
-docker run --rm -it -w /tmp/src -v `pwd`:/tmp/src --network "container:$CONTAINER_DB" -e PGPASSWORD=osm openmap/osm2pgsql:latest osm2pgsql -s -c -C 512 --multi-geometry -S db/osm2pgsql.style -d osm -U osm -H db data.pbf
-docker exec -u postgres $CONTAINER_DB sh -c 'psql osm -f /src/db/index.sql'
-docker exec -u postgres $CONTAINER_DB sh -c 'cat /src/db/func/*.sql | psql osm -f -'
+docker run --rm -it \
+    -w /tmp/src \
+    -v "$(pwd):/tmp/src" \
+    --network "container:$CONTAINER_DB" \
+    -e PGPASSWORD=osm openmap/osm2pgsql:latest \
+    osm2pgsql \
+        -s -c -C 512 --multi-geometry \
+        -S db/osm2pgsql.style \
+        -d osm -U osm \
+        -H db \
+        data.pbf
 
-docker exec -u postgres $CONTAINER_DB sh -c 'psql osm -f /src/db/tables/table_poi.sql'
-docker exec -u postgres $CONTAINER_DB sh -c 'psql osm -f /src/db/tables/table_gen_ways.sql'
+# dbfunc yra masyvas (array) iš visų db/func/*.sql failų
+dbfunc=(db/func/*.sql)
+# dbfuncfiles yra dbfunc failai su '-f' prefix'u.
+# atskirus failus yra geriau paduoti postgresql, nei viską cat'inti,
+# nes, jei įvyksta klaida, psql gali pasakyti failo pavadinimą
+# ir eilutės numerį, kur įvyko klaida.
+dbfuncfiles=("${dbfunc[@]/#/-f }")
+docker exec -w /src "$CONTAINER_DB" psql osm -U osm \
+    -f db/index.sql \
+    "${dbfuncfiles[@]}" \
+    -f db/tables/table_poi.sql \
+    -f db/tables/table_gen_ways.sql \
+    -f db/gen_way.sql \
+    -f db/gen_water.sql \
+    -f db/gen_building.sql \
+    -f db/gen_forest.sql \
+    -f db/gen_protected.sql
 
-docker exec -u postgres $CONTAINER_DB sh -c 'psql osm -f /src/db/gen_way.sql'
-docker exec -u postgres $CONTAINER_DB sh -c 'psql osm -f /src/db/gen_water.sql'
-docker exec -u postgres $CONTAINER_DB sh -c 'psql osm -f /src/db/gen_building.sql'
-docker exec -u postgres $CONTAINER_DB sh -c 'psql osm -f /src/db/gen_forest.sql'
-docker exec -u postgres $CONTAINER_DB sh -c 'psql osm -f /src/db/gen_protected.sql'
-
-docker exec -u postgres $CONTAINER_DB sh -c 'bzip2 -cd /src/data/coastline/coastline.sql.bz2 | psql osm'
-docker exec -u postgres -w /src/db/upiu_baseinai $CONTAINER_DB ./go.sh
+docker exec -w /src "$CONTAINER_DB" bash <<-EOF
+set -euo pipefail
+bzip2 -cd data/coastline/coastline.sql.bz2 | psql -U osm osm
+db/upiu_baseinai/go.sh
+EOF

--- a/db/reset_db.sh
+++ b/db/reset_db.sh
@@ -4,6 +4,6 @@ if [ ! -e data.pbf ]; then
 	wget -O data.pbf http://download.geofabrik.de/europe/lithuania-latest.osm.pbf
 fi
 
-./osm2pgsql -s -c -C 1024 -E 3857 --multi-geometry -S ./osm2pgsql.style -d osm -U postgres data.pbf
-psql -d osm -U postgres < index.sql
-psql -d osm -U postgres -c 'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO osm;'
+./osm2pgsql -s -c -C 1024 -E 3857 --multi-geometry -S ./osm2pgsql.style -d osm -U osm data.pbf
+psql -d osm -U osm < index.sql
+psql -d osm -U osm -c 'GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO osm;'

--- a/db/update.sh
+++ b/db/update.sh
@@ -41,12 +41,12 @@ if [ $? -ne 0 ]; then
 fi
 
 # remove outside objects
-psql -d osm -U postgres < remove_outside_objects.sql
+psql -d osm -U osm < remove_outside_objects.sql
 
 echo "Refreshing materialized views " `date`
-psql -d osm -U postgres < update_mv.sql
+psql -d osm -U osm < update_mv.sql
 echo "Refreshing waterbody labels " `date`
-psql -d osm -U postgres < update_water_labels.sql
+psql -d osm -U osm < update_water_labels.sql
 
 # atsiminti dienos kaladėles savaitgaliui (šeštadieniui)
 cat dirty_tiles >> dirty_tiles_weekly
@@ -54,7 +54,7 @@ cat dirty_tiles >> dirty_tiles_weekly
 # update generalisation on Saturday
 if [[ $(date +%u) -eq 6 ]] ; then
   echo "way generalisation" `date`
-  psql -d osm -U postgres < gen_way.sql
+  psql -d osm -U osm < gen_way.sql
   echo "water generalisation" `date`
   psql -d osm -U osm < gen_water.sql
   echo "building generalisation" `date`

--- a/db/upiu_baseinai/go.sh
+++ b/db/upiu_baseinai/go.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
-set -e
-psql osm -U osm < upiu_baseinai.sql
-psql osm -U osm < merge_water.sql
-psql osm -U osm < touch.sql
-psql osm -U osm < process.sql
-psql osm -U osm < process_plot.sql
+set -eu
+here=$(dirname "$0")
+
+psql osm -U osm < "${here}/upiu_baseinai.sql"
+psql osm -U osm < "${here}/merge_water.sql"
+psql osm -U osm < "${here}/touch.sql"
+psql osm -U osm < "${here}/process.sql"
+psql osm -U osm < "${here}/process_plot.sql"


### PR DESCRIPTION
1. visur naudojame `osm` vartotoją.
2. abu skriptai dabar praeina [shellcheck][1].
3. `db/upiu_baseinai/go.sh` galima kviesti iš bet kur.
4. `set -euo pipefail` abiejuose. Taip išvengsime paslėptų klaidų.

Kitas etapas, kiek vėliau -- pridėti CI, kuris užtikrintų, kad docker-based paleidimas nesulūš. Tai -- viena priežasčių, dėl kurių gana liberaliai pridėjau `set -euo pipefail` visur, ką liečiau.

[1]: https://www.shellcheck.net/