### PR TITLE
vienas network namespace visiems konteineriams

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -1,49 +1,49 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -xeuo pipefail
 
 if [ ! -e data.pbf ]; then
 	wget -O data.pbf http://download.geofabrik.de/europe/lithuania-latest.osm.pbf
 fi
 
-CONTAINER_DB=$(docker-compose ps -q db)
-
 # load data
-docker run --rm -it \
-    -w /tmp/src \
-    -v "$(pwd):/tmp/src" \
-    --network "container:$CONTAINER_DB" \
-    -e PGPASSWORD=osm openmap/osm2pgsql:latest \
-    osm2pgsql \
-        -s -c -C 512 --multi-geometry \
-        -S db/osm2pgsql.style \
-        -d osm -U osm \
-        -H db \
-        data.pbf
+docker-compose exec -T db bash -xeuo pipefail <<-EOF
+export PGPASSWORD=osm
+
+if ! command -v osm2pgsql > /dev/null; then
+    apt-get update
+    apt-get install -y osm2pgsql bzip2
+fi
 
 # aktyvuojame postgis_sfcgal; jei neaktyvuojamas, neranda funkcijų
-docker exec -i "$CONTAINER_DB" psql osm -U osm -c 'CREATE EXTENSION postgis_sfcgal;'
+psql osm -U osm -c 'CREATE EXTENSION IF NOT EXISTS postgis_sfcgal;'
+
+osm2pgsql \
+    -s -c -C 512 --multi-geometry \
+    -S /src/db/osm2pgsql.style \
+    -d osm -U osm \
+    /src/data.pbf
+EOF
 
 # dbfunc yra masyvas (array) iš visų db/func/*.sql failų
 dbfunc=(db/func/*.sql)
-# dbfuncfiles yra dbfunc failai su '-f' prefix'u.
+# dbfuncfiles yra dbfunc failai su '-f /src/' prefix'u.
 # atskirus failus yra geriau paduoti postgresql, nei viską cat'inti,
 # nes, jei įvyksta klaida, psql gali pasakyti failo pavadinimą
 # ir eilutės numerį, kur įvyko klaida.
-dbfuncfiles=("${dbfunc[@]/#/-f }")
+dbfuncfiles=("${dbfunc[@]/#/-f /src/}")
 # shellcheck disable=SC2068
-docker exec -i -w /src "$CONTAINER_DB" psql osm -U osm \
-    -f db/index.sql \
+docker-compose exec db psql osm -U osm \
+    -f /src/db/index.sql \
     ${dbfuncfiles[@]} \
-    -f db/tables/table_poi.sql \
-    -f db/tables/table_gen_ways.sql \
-    -f db/gen_way.sql \
-    -f db/gen_water.sql \
-    -f db/gen_building.sql \
-    -f db/gen_forest.sql \
-    -f db/gen_protected.sql
+    -f /src/db/tables/table_poi.sql \
+    -f /src/db/tables/table_gen_ways.sql \
+    -f /src/db/gen_way.sql \
+    -f /src/db/gen_water.sql \
+    -f /src/db/gen_building.sql \
+    -f /src/db/gen_forest.sql \
+    -f /src/db/gen_protected.sql
 
-docker exec -w /src "$CONTAINER_DB" bash <<-EOF
-set -euo pipefail
-bzip2 -cd data/coastline/coastline.sql.bz2 | psql -U osm osm
-db/upiu_baseinai/go.sh
+docker-compose exec -T db bash -xeuo pipefail <<-EOF
+bzip2 -cd /src/data/coastline/coastline.sql.bz2 | psql -U osm osm
+/src/db/upiu_baseinai/go.sh
 EOF

--- a/config.toml.template
+++ b/config.toml.template
@@ -8,7 +8,7 @@ basepath = "/home/openmap/cache"
 [[providers]]
 name = "osm"
 type = "postgis"
-host = "${PGHOST}"
+host = "127.0.0.1"
 port = 5432
 database = "osm"
 user = "osm"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,38 +3,43 @@ version: "2"
 services:
   tegola:
     image: debian:stable-slim
-    links: ["db"]
-    environment:
-      PGHOST: db
+    network_mode: service:net
     working_dir: /src
     entrypoint: /bin/sh -c "/src/generate_config.sh && /src/tegola serve --config /src/config.toml"
     volumes:
-      - ".:/src"
+      - ".:/src" # for tegola binary and config.toml
 
   db:
     image: postgis/postgis:13-3.0
+    network_mode: service:net
     environment:
       POSTGRES_DBNAME: osm
       POSTGRES_USER: osm
       POSTGRES_PASSWORD: osm
     volumes:
-      - ".:/src"
+      - ".:/src:ro"
       - "/var/lib/postgresql"
 
   web:
     image: node:alpine
-    ports: ["80:8000"]
-    links: ["tegola"]
+    network_mode: service:net
     environment:
       PUBLIC_PATH: "/var/www"
       TILES_URL: "http://tegola:8082/all/{z}/{x}/{y}.pbf"
     working_dir: "/srv/proxy"
     volumes:
-      - "./demo:/var/www"
-      - "./proxy:/srv/proxy"
+      - "./demo:/var/www:ro"
+      - "./proxy:/srv/proxy:ro"
     command: ["/srv/proxy/server.sh"]
 
   maputnik:
     image: maputnik/editor:latest
-    ports: ["8888:8888"]
+    network_mode: service:net
 
+  net:
+    image: debian:stable-slim
+    entrypoint: ["tail", "-f", "/dev/null"]
+    ports:
+      - "5432:5432" # postgresql
+      - "8888:8888" # tegola
+      - "8080:80"   # proxy

--- a/generate_config.sh
+++ b/generate_config.sh
@@ -18,10 +18,4 @@ do
    fi
 done < $CONFIG_TEMP
 
-sed -i "s|##|\&\&|g" $CONFIG_TEMP
-
-DBHOST=${PGHOST:-"localhost"}
-# somehow `db` was not resolving properly from tegola container
-HOSTIP=`getent hosts db | awk '{ print $1 }'`
-PGHOST=${HOSTIP} envsubst < $CONFIG_TEMP > $CONFIG_FILE
-rm $CONFIG_TEMP
+sed "s|##|\&\&|g" $CONFIG_TEMP > $CONFIG_FILE


### PR DESCRIPTION
Viskas dabar klausysis ir bus pasiekiama `127.0.0.1:*`. Taip bus paprasčiausia jungtis iš DB prie visų konteinerių ir tvarkytis su proxy.

- Kadangi tinklą turime vietoje, dabar labai paprasta naudoti `osm2pgsql` iš postgis konteinerio; taip atsisiųsime dar vienu konteineriu mažiau.
- `proxy` ir `db` `/src/` katalogą gauna read-only. `tegola` konteineris gauna read-write, nes ten įrašo `config.toml`, ką, įsivaizduoju, yra gana patogu matyti ieškant klaidų.