### PR TITLE
Elasticsearch paieškai

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -11,7 +11,7 @@ export PGPASSWORD=osm
 
 if ! command -v osm2pgsql > /dev/null; then
     apt-get update
-    apt-get install -y osm2pgsql
+    apt-get install -y osm2pgsql jq curl
 fi
 
 # aktyvuojame postgis_sfcgal; jei neaktyvuojamas, neranda funkcijų
@@ -22,6 +22,9 @@ osm2pgsql \
     -S /src/db/osm2pgsql.style \
     -d osm -U osm \
     /src/data.pbf
+
+/src/db/db2es
+/src/db/db2es-test
 EOF
 
 # dbfunc yra masyvas (array) iš visų db/func/*.sql failų

--- a/db/db2es
+++ b/db/db2es
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -euo pipefail
+here=$(dirname "$0")
+
+for cmd in curl jq psql split; do
+    if ! command -v "$cmd" >/dev/null; then
+        echo "ERROR: missing $cmd in \$PATH"
+        exit 1
+    fi
+done
+
+# laikina direktorija išvesčiai į ES
+tmpdir=$(mktemp -d)
+# Pabaidoje ištrinsim direktoriją su laikinais failais.
+# Jei reikia debuginti, užkomentuok eilutę.
+trap 'echo Deleting $tmpdir; rm -fr $tmpdir' EXIT
+
+echo -n "Deleting index osm if exists: "
+curl -XDELETE "localhost:9200/osm" --silent
+echo
+
+echo -n "Creating index osm: "
+curl -XPUT "localhost:9200/osm" --silent --fail \
+    --header 'Content-Type: application/json' \
+    --data-binary "@$here/es-schema.json"
+echo
+
+# Imame įrašus iš duombazės ir formuojame JSON ES bulk įvesčiai:
+# - vienas įrašas DB - viena eilutė JSON.
+# - kiekvienas įrašas gauna naują {"index": {"_id": <id>}} eilutę. Žr. [1].
+# - po jos seka tas pats įrašas be "id" lauko.
+# tada įrašus skeliame į atskirus failus. kadangi dvi eilutės yra vienas
+# įrašas, `--lines` visada turi būti lyginis.
+#
+# [1]: https://elastic.co/guide/en/elasticsearch/reference/7.9/docs-bulk.html
+PGPASSWORD=osm psql -h127.0.0.1 -U osm osm --tuples-only --no-align \
+    -f "$here/db2es.sql" | \
+  jq --compact-output '{index:{_id:.id|tostring}} , (.|del(.id))' | \
+  split --verbose --lines=200000 - "$tmpdir/es-"
+
+# siunčiame ES po vieną failą
+for f in "$tmpdir"/es-*; do
+  echo -n "Posting $f with $(($(wc -l <"$f")/2)) records: "
+  output=$(curl "localhost:9200/osm/_bulk?filter_path=took,errors,items.*.error" \
+      --silent --fail \
+      --header "Content-Type: application/x-ndjson" \
+      --data-binary "@$f")
+    if [[ $(jq .errors <<<"$output") == true ]]; then
+        echo "failed: $output"
+        exit 1
+    else
+        echo "ok, took $(jq .took <<<"$output")ms"
+    fi
+done
+
+# fsync: iš karto galima siųsti klausimus ES ir tikėtis teisingų atsakymų.
+curl -XPOST "localhost:9200/osm/_flush" --silent --fail -o/dev/null

--- a/db/db2es-test
+++ b/db/db2es-test
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+# Jei nėra nei vienos Špunkos, kažkas blogai su duomenų importu.
+curl -XGET localhost:9200/osm/_search --silent --fail \
+    --header 'Content-Type: application/json' --data '
+{
+  "query": {
+    "match": {
+      "name": "Špunka"
+    }
+  }
+}' | jq -e '.hits.total.value > 0'
+
+# TODO: daugiau testų. Čia yra nebloga vieta prasitestuoti ES užklausas.

--- a/db/db2es.sql
+++ b/db/db2es.sql
@@ -1,0 +1,46 @@
+SELECT
+    json_strip_nulls (row_to_json(t))
+FROM (
+    SELECT
+        osm_id AS id,
+        "addr:city" AS city,
+        "addr:street" AS street,
+        "addr:housenumber" AS housenumber,
+        "addr:unit" AS unit,
+        name AS name,
+        alt_name AS alt_name,
+        official_name AS official_name,
+        description AS description,
+        ST_AsText (ST_Transform (way, 4326)) AS location
+    FROM
+        planet_osm_point
+    WHERE
+        historic IS NOT NULL
+        OR tourism IN ('hotel', 'motel', 'hostel', 'guest_house', 'camp_site', 'caravan_site')
+        OR amenity IN ('restaurant', 'cafe', 'bar')
+        OR tourism IN ('museum', 'attraction', 'viewpoint')
+        OR waterway IN ('river', 'stream', 'canal')
+        OR admin_level IS NOT NULL
+        OR "addr:city" IS NOT NULL
+    UNION
+    SELECT
+        osm_id AS id,
+        "addr:city" AS city,
+        "addr:street" AS street,
+        "addr:housenumber" AS housenumber,
+        "addr:unit" AS unit,
+        name AS name,
+        alt_name AS alt_name,
+        official_name AS official_name,
+        description AS description,
+        ST_AsText (ST_Transform (ST_PointOnSurface (way), 4326)) AS location
+    FROM
+        planet_osm_polygon
+    WHERE
+        historic IS NOT NULL
+        OR tourism IN ('hotel', 'motel', 'hostel', 'guest_house', 'camp_site', 'caravan_site')
+        OR amenity IN ('restaurant', 'cafe', 'bar')
+        OR tourism IN ('museum', 'attraction', 'viewpoint')
+        OR waterway IN ('river', 'stream', 'canal')
+        OR admin_level IS NOT NULL
+        OR "addr:city" IS NOT NULL) AS t

--- a/db/es-schema.json
+++ b/db/es-schema.json
@@ -1,0 +1,15 @@
+{
+  "mappings": {
+    "properties": {
+      "city":          { "type": "keyword" },
+      "street":        { "type": "keyword" },
+      "housenumber":   { "type": "keyword" },
+      "unit":          { "type": "keyword" },
+      "name":          { "type": "text" },
+      "alt_name":      { "type": "text" },
+      "official_name": { "type": "text" },
+      "description":   { "type": "text"},
+      "location":      { "type": "geo_point"}
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,14 @@ services:
       - ".:/src:ro"
       - "/var/lib/postgresql"
 
+  es:
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.9.3-amd64
+    network_mode: service:net
+    environment:
+      discovery.type: single-node
+    volumes:
+      - "/usr/share/elasticsearch/data"
+
   web:
     image: nginx:stable
     network_mode: service:net
@@ -36,5 +44,6 @@ services:
     entrypoint: ["tail", "-f", "/dev/null"]
     ports:
       - "5432:5432" # postgresql
-      - "8888:8888" # tegola
       - "8080:8080" # web -- nginx
+      - "8888:8888" # maputnik
+      - "9200:9200" # elastic


### PR DESCRIPTION
Pridedame:
- elasticsearch localdev'ui.
- naivų indeksą.
- duomeų importavimą iš `planet_osm_point` ir `planet_osm_polygon`
- labai paprastą testą, kuris randa vieną objektą Vilniuje.

Tolesni žingsniai -- formuoti indeksą ir užklausas taip, kad rastų, pvz., "Špunk", ir, aišku, pagal adresą.

Importavimo laikas visiems Lietuvos objektams:
```
motiejus ~/code/vector-map $ time ./db/db2es
Deleting index osm if exists: {"acknowledged":true}
Creating index osm: {"acknowledged":true,"shards_acknowledged":true,"index":"osm"}
creating file '/tmp/tmp.n29p29DI07/es-aa'
creating file '/tmp/tmp.n29p29DI07/es-ab'
creating file '/tmp/tmp.n29p29DI07/es-ac'
creating file '/tmp/tmp.n29p29DI07/es-ad'
Posting /tmp/tmp.n29p29DI07/es-aa with 100000 records: ok, took 1298ms
Posting /tmp/tmp.n29p29DI07/es-ab with 100000 records: ok, took 1114ms
Posting /tmp/tmp.n29p29DI07/es-ac with 100000 records: ok, took 1152ms
Posting /tmp/tmp.n29p29DI07/es-ad with 15286 records: ok, took 183ms
Deleting /tmp/tmp.n29p29DI07

real    0m15.452s
user    0m3.394s
sys     0m0.270s
motiejus ~/code/vector-map $ 
```