### PR TITLE
t ir d tipams

### DIFF
--- a/db/db2es
+++ b/db/db2es
@@ -33,7 +33,7 @@ echo
 # įrašas, `--lines` visada turi būti lyginis.
 #
 # [1]: https://elastic.co/guide/en/elasticsearch/reference/7.9/docs-bulk.html
-PGPASSWORD=osm psql -h127.0.0.1 -U osm osm --tuples-only --no-align \
+PGPASSWORD=osm psql -h127.0.0.1 --no-psqlrc --tuples-only --no-align -U osm osm \
     -f "$here/db2es.sql" | \
   jq --compact-output '{index:{_id:.id|tostring}} , (.|del(.id))' | \
   split --verbose --lines=200000 - "$tmpdir/es-"

--- a/db/db2es.sql
+++ b/db/db2es.sql
@@ -1,6 +1,6 @@
 WITH t1 AS (
     SELECT
-        osm_id AS id,
+        't' || osm_id AS id,
         "addr:city" AS city,
         "addr:street" AS street,
         "addr:housenumber" AS housenumber,
@@ -23,7 +23,7 @@ WITH t1 AS (
         OR "addr:city" IS NOT NULL
     UNION
     SELECT
-        osm_id AS id,
+        'd' || osm_id AS id,
         "addr:city" AS city,
         "addr:street" AS street,
         "addr:housenumber" AS housenumber,


### PR DESCRIPTION
taškai gaus 't' prefix'ą, daugiakampiai gaus 'd'.

Tuo pačiu: kad importavimas nepriklausytų nuo nesąmonių (kaip pas mane) `~/.psqlrc`.