### PR TITLE
"name" normalization

### DIFF
--- a/es/es-schema.json
+++ b/es/es-schema.json
@@ -1,16 +1,65 @@
 {
   "mappings": {
     "properties": {
-      "city":          { "type": "keyword" },
-      "street":        { "type": "keyword" },
-      "housenumber":   { "type": "keyword" },
-      "postcode":      { "type": "keyword" },
-      "unit":          { "type": "keyword" },
-      "name":          { "type": "text" },
-      "alt_name":      { "type": "text" },
-      "official_name": { "type": "text" },
-      "description":   { "type": "text"},
-      "location":      { "type": "geo_point"}
+      "city": {
+        "type": "keyword"
+      },
+      "street": {
+        "type": "keyword"
+      },
+      "housenumber": {
+        "type": "keyword"
+      },
+      "postcode": {
+        "type": "keyword"
+      },
+      "unit": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "text",
+        "analyzer": "autocomplete"
+      },
+      "alt_name": {
+        "type": "text"
+      },
+      "official_name": {
+        "type": "text"
+      },
+      "description": {
+        "type": "text"
+      },
+      "location": {
+        "type": "geo_point"
+      }
+    }
+  },
+  "settings": {
+    "number_of_shards": 1,
+    "analysis": {
+      "filter": {
+        "lithuanian_stemmer": {
+          "type": "stemmer",
+          "language": "lithuanian"
+        },
+        "autocomplete_filter": {
+          "type": "edge_ngram",
+          "min_gram": 1,
+          "max_gram": 20
+        }
+      },
+      "analyzer": {
+        "autocomplete": {
+          "type": "custom",
+          "tokenizer": "standard",
+          "filter": [
+            "lowercase",
+            "asciifolding",
+            "lithuanian_stemmer",
+            "autocomplete_filter"
+          ]
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Prepares "name" field for autocomplete and lithuanian search with the following filters:
- lowercase: so "špunka" can be found.
- asciifolding: so "špunka" and "spunka" are the same thing.
- lithuanian_stemmer: "spunkai" and "spunkos" are about the same.
- autocomplete_filter: ngram filter, which enables autocomplete.

```
motiejus ~ $ curl -s http://localhost:8080/api/search?q=spunk | jq . | head -60
{
  "took": 6,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 1291,
      "relation": "eq"
    },
    "max_score": 2.991993,
    "hits": [
      {
        "_index": "osm",
        "_type": "_doc",
        "_id": "t2265668604",
        "_score": 2.991993,
        "_source": {
          "city": "Vilnius",
          "street": "Užupio g.",
          "housenumber": "9",
          "name": "Špunka",
          "description": "Alaus ir giros krautuvė",
          "location": [
            54.6805328993302,
            25.2955115
          ]
        }
      },
      {
        "_index": "osm",
        "_type": "_doc",
        "_id": "t2811970425",
        "_score": 2.991993,
        "_source": {
          "city": "Vilnius",
          "street": "Savičiaus g.",
          "housenumber": "9",
          "name": "Špunka",
          "location": [
            54.6792189993299,
            25.2892532
          ]
        }
      },
      {
        "_index": "osm",
        "_type": "_doc",
        "_id": "t3118299290",
        "_score": 2.991993,
        "_source": {
          "city": "Vilnius",
          "street": "Kęstučio g.",
          "housenumber": "55",
          "name": "Špunka",
          "description": "Alaus ir giros krautuvė",
```