### PR TITLE
Aggreguojamos upės ir gatvės

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -46,7 +46,8 @@ docker-compose exec db psql osm -U osm \
     -f /src/data/coastline/coastline.sql
 
 docker-compose exec db bash -xeuo pipefail <<-EOF
-/src/db/upiu_baseinai/go.sh
 /src/es/db2es
 /src/es/db2es-test
 EOF
+
+docker-compose exec -T db /src/db/upiu_baseinai/go.sh

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -43,7 +43,7 @@ docker-compose exec db psql osm -U osm \
     -f /src/db/gen_building.sql \
     -f /src/db/gen_forest.sql \
     -f /src/db/gen_protected.sql \
-    -f /src/data/coastline/coastline.sql \
+    -f /src/data/coastline/coastline.sql
 
 docker-compose exec db bash -xeuo pipefail <<-EOF
 /src/db/upiu_baseinai/go.sh

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -22,9 +22,6 @@ osm2pgsql \
     -S /src/db/osm2pgsql.style \
     -d osm -U osm \
     /src/data.pbf
-
-/src/es/db2es
-/src/es/db2es-test
 EOF
 
 # dbfunc yra masyvas (array) iš visų db/func/*.sql failų
@@ -38,6 +35,7 @@ dbfuncfiles=("${dbfunc[@]/#/-f /src/}")
 docker-compose exec db psql osm -U osm \
     -f /src/db/index.sql \
     ${dbfuncfiles[@]} \
+    -f /src/es/agg-linear-objects.sql \
     -f /src/db/tables/table_poi.sql \
     -f /src/db/tables/table_gen_ways.sql \
     -f /src/db/gen_way.sql \
@@ -45,6 +43,10 @@ docker-compose exec db psql osm -U osm \
     -f /src/db/gen_building.sql \
     -f /src/db/gen_forest.sql \
     -f /src/db/gen_protected.sql \
-    -f /src/data/coastline/coastline.sql
+    -f /src/data/coastline/coastline.sql \
 
-docker-compose exec -T db /src/db/upiu_baseinai/go.sh
+docker-compose exec db bash -xeuo pipefail <<-EOF
+/src/db/upiu_baseinai/go.sh
+/src/es/db2es
+/src/es/db2es-test
+EOF

--- a/es/agg-linear-objects.sql
+++ b/es/agg-linear-objects.sql
@@ -1,0 +1,48 @@
+/* Aggregates streets or rivers by name and proximity. */
+drop function if exists agg_linear_objects;
+create or replace function agg_linear_objects(p_type text) returns table(osm_id bigint, name text, alt_name text, way geometry) as $$
+declare
+  c record;
+  cc record;
+  changed boolean;
+begin
+  create temporary table agg_tmp_objects (osm_id bigint, name text, alt_name text, way geometry);
+  create index agg_tmp_objects_id on agg_tmp_objects(osm_id);
+  create index agg_tmp_objects_gix on agg_tmp_objects using gist(way) include(name);
+
+  if p_type = 'rivers' then
+    insert into agg_tmp_objects
+      select p.osm_id, coalesce(p."name:lt", p.name), p.alt_name, p.way from planet_osm_line p
+        where waterway in ('river', 'stream') and p.name is not null;
+  elsif p_type = 'streets' then
+    insert into agg_tmp_objects
+      select p.osm_id, coalesce(p."name:lt", p.name), p.alt_name, p.way from planet_osm_line p
+        where highway in ('motorway', 'trunk', 'primary', 'secondary', 'tertiary',
+          'unclassified', 'residential', 'track', 'living_street') and p.name is not null;
+  else
+    raise 'p_type can only be "rivers" or "streets"';
+  end if;
+
+  while (select count(1) from agg_tmp_objects) > 0 loop
+    select * from agg_tmp_objects limit 1 into c;
+    delete from agg_tmp_objects a where a.osm_id = c.osm_id;
+    changed = true;
+    while changed loop
+      changed = false;
+      for cc in (select * from agg_tmp_objects a where a.name = c.name and st_dwithin(a.way, c.way, 500)) loop
+        c.way = st_linemerge(st_union(c.way, cc.way));
+        delete from agg_tmp_objects a where a.osm_id = cc.osm_id;
+        changed = true;
+      end loop;
+    end loop; -- while changed
+    return query select c.osm_id, c.name, c.alt_name, c.way;
+  end loop; -- count(1) from agg_tmp_objects > 0
+  drop table agg_tmp_objects;
+  return;
+end
+$$ language plpgsql;
+
+drop table if exists agg_streets;
+drop table if exists agg_rivers;
+create table agg_streets as (select * from agg_linear_objects('streets'));
+create table agg_rivers as (select * from agg_linear_objects('rivers'));

--- a/es/agg-linear-objects.sql
+++ b/es/agg-linear-objects.sql
@@ -13,7 +13,7 @@ begin
   if p_type = 'rivers' then
     insert into agg_tmp_objects
       select p.osm_id, coalesce(p."name:lt", p.name), p.alt_name, p.way from planet_osm_line p
-        where waterway in ('river', 'stream') and p.name is not null;
+        where waterway in ('river', 'stream', 'canal') and p.name is not null;
   elsif p_type = 'streets' then
     insert into agg_tmp_objects
       select p.osm_id, coalesce(p."name:lt", p.name), p.alt_name, p.way from planet_osm_line p


### PR DESCRIPTION
Sukuria 2 naujas lentas `agg_streets` ir `agg_rivers` su sujungtais kelių ir upių objektais.

Kitas PR -- sudėti juos į ES indeksą vietoj dabartinių upių ir gatvių.