### PR TITLE
keičiame postgis versiją į produkcinę

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - ".:/src" # for tegola binary and config.toml
 
   db:
-    image: postgis/postgis:13-3.0
+    image: postgis/postgis:11-2.5
     network_mode: service:net
     environment:
       POSTGRES_DBNAME: osm


### PR DESCRIPTION
Iš @tomass žinutės apie produkcinę versiją:
```
osm=# select version();

                                                                    version                                                                     
-----------------------------------------------------------------------------------------------------------------------------------------------

 PostgreSQL 11.10 (Ubuntu 11.10-1.pgdg16.04+1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 5.4.0-6ubuntu1~16.04.12) 5.4.0 20160609, 64-bit

osm=# select postgis_version();      
            postgis_version             
---------------------------------------

 2.5 USE_GEOS=1 USE_PROJ=1 USE_STATS=1
```