### PR TITLE
Paieškos indeksas: full_text laukas, analizatoriaus pakeitimai

### DIFF
--- a/es/db2es.sql
+++ b/es/db2es.sql
@@ -54,16 +54,21 @@ WITH t1 AS (
              when "natural" = 'stone' then 'STO'
              when "natural" = 'tree' then 'TRE'
              when "natural" = 'spring' then 'SPR'
-             else 'DEF' end AS obj_type,
+             when "addr:city" is not null then 'ADD'
+             else 'DF1' end AS obj_type,
         "addr:city" AS city,
         "addr:street" AS street,
-        "addr:housenumber" AS housenumber,
+        lpad("addr:housenumber", 3, '0') AS housenumber,
         "addr:postcode" AS postcode,
         "addr:unit" AS unit,
         COALESCE("name:lt", name) AS name,
         alt_name AS alt_name,
         official_name AS official_name,
         description AS description,
+        coalesce(name, '') || ' ' ||
+        coalesce("addr:city", '') || ' ' ||
+        coalesce("addr:street") || ' ' ||
+        coalesce(lpad("addr:housenumber", 3, '0'), '') AS full_text,
         ST_Transform (way, 4326) AS location
     FROM
         planet_osm_point
@@ -130,16 +135,21 @@ WITH t1 AS (
              when "natural" = 'stone' then 'STO'
              when "natural" = 'tree' then 'TRE'
              when "natural" = 'spring' then 'SPR'
-             else 'DEF' end AS obj_type,
+             when "addr:city" is not null then 'ADD'
+             else 'DF2' end AS obj_type,
         "addr:city" AS city,
         "addr:street" AS street,
-        "addr:housenumber" AS housenumber,
+        lpad("addr:housenumber", 3, '0') AS housenumber,
         "addr:postcode" AS postcode,
         "addr:unit" AS unit,
         COALESCE("name:lt", name) AS name,
         alt_name AS alt_name,
         official_name AS official_name,
         description AS description,
+        coalesce(name, '') || ' ' ||
+        coalesce("addr:city", '') || ' ' ||
+        coalesce("addr:street", '') || ' ' ||
+        coalesce(lpad("addr:housenumber", 3, '0'), '') AS full_text,
         ST_Transform (ST_PointOnSurface (way), 4326) AS location
     FROM
         planet_osm_polygon
@@ -157,7 +167,7 @@ WITH t1 AS (
         end AS id,
         case when object_type = 'r' then 'RIV'
              when object_type = 's' then 'STR'
-             else 'DEF'
+             else 'DF3'
         end AS obj_type,
         null AS city,
         null AS street,
@@ -168,6 +178,7 @@ WITH t1 AS (
         null AS alt_name,
         null AS official_name,
         null AS description,
+        ao.name AS full_text,
         ST_Transform(ST_ClosestPoint(ao.way, ST_Centroid(ao.way)), 4326) AS location
     FROM
         agg_objects ao
@@ -187,6 +198,7 @@ FROM (
         alt_name,
         official_name,
         description,
+        full_text,
         ARRAY[ST_Y (location), ST_X (location)] AS location
     FROM
         t1) AS t2

--- a/es/es-schema.json
+++ b/es/es-schema.json
@@ -5,10 +5,14 @@
         "type": "keyword"
       },
       "city": {
-        "type": "keyword"
+        "type": "text",
+        "analyzer": "customAnalyser",
+        "search_analyzer": "customSearchAnalyser"
       },
       "street": {
-        "type": "keyword"
+        "type": "text",
+        "analyzer": "customAnalyser",
+        "search_analyzer": "customSearchAnalyser"
       },
       "housenumber": {
         "type": "keyword"
@@ -17,20 +21,34 @@
         "type": "keyword"
       },
       "unit": {
-        "type": "keyword"
+        "type": "text",
+        "analyzer": "customAnalyser",
+        "search_analyzer": "customSearchAnalyser"
       },
       "name": {
         "type": "text",
-        "analyzer": "autocomplete"
+        "analyzer": "customAnalyser",
+        "search_analyzer": "customSearchAnalyser"
       },
       "alt_name": {
-        "type": "text"
+        "type": "text",
+        "analyzer": "customAnalyser",
+        "search_analyzer": "customSearchAnalyser"
       },
       "official_name": {
-        "type": "text"
+        "type": "text",
+        "analyzer": "customAnalyser",
+        "search_analyzer": "customSearchAnalyser"
       },
       "description": {
-        "type": "text"
+        "type": "text",
+        "analyzer": "customAnalyser",
+        "search_analyzer": "customSearchAnalyser"
+      },
+      "full_text": {
+        "type": "text",
+        "analyzer": "customAnalyser",
+        "search_analyzer": "customSearchAnalyser"
       },
       "location": {
         "type": "geo_point"
@@ -39,6 +57,9 @@
   },
   "settings": {
     "number_of_shards": 1,
+    "index": {
+      "max_ngram_diff": 8
+    },
     "analysis": {
       "filter": {
         "lithuanian_stemmer": {
@@ -47,8 +68,17 @@
         },
         "autocomplete_filter": {
           "type": "edge_ngram",
-          "min_gram": 1,
+          "min_gram": 2,
           "max_gram": 20
+        },
+        "no_stop": {
+          "type": "stop",
+          "stopwords": "_none_"
+        },
+        "ngram_filter": {
+          "type": "ngram",
+          "min_gram": "3",
+          "max_gram": "10"
         }
       },
       "analyzer": {
@@ -61,6 +91,17 @@
             "lithuanian_stemmer",
             "autocomplete_filter"
           ]
+        },
+        "customSearchAnalyser": {
+         "type": "custom",
+         "stopwords": "_none_",
+         "filter": ["lowercase", "asciifolding", "no_stop"],
+         "tokenizer": "whitespace"
+        },
+        "customAnalyser": {
+          "type": "custom",
+          "filter": ["lowercase", "asciifolding", "no_stop", "ngram_filter"],
+          "tokenizer": "whitespace"
         }
       }
     }


### PR DESCRIPTION
1. Pridėtas full_text laukas paprastesnei paieškai.
2. Namo numeris pildomas iki trijų skaitmenų nuliais, tas pats daroma ir kliento pusėje, kad ieškant 2, nebūtų tinkami variantai 20 ar 120.
3. Pakeisti paieškos indekso laukų tipai ir antalizatorius.