### PR TITLE
Upių žemėlapių pavojingos vietos ir generalizacija

### DIFF
--- a/db/tables/table_poi_river_gen.sql
+++ b/db/tables/table_poi_river_gen.sql
@@ -9,6 +9,7 @@ SELECT cid
       ,min(distance) distance
       ,CASE array_to_string(array_agg(whitewater order by distance desc),';')
         WHEN '' THEN 'milestone'
+        WHEN 'egress;bridge' THEN 'inout_bridge'
         WHEN 'put_in;egress;bridge' THEN 'inout_bridge'
         WHEN 'bridge;egress' THEN 'bridge_inout'
         WHEN 'bridge;put_in' THEN 'bridge_inout'

--- a/demo/sprites/river.json
+++ b/demo/sprites/river.json
@@ -265,6 +265,13 @@
     "x": 104,
     "y": 128
   },
+  "hazard": {
+    "height": 22,
+    "pixelRatio": 1,
+    "width": 22,
+    "x": 104,
+    "y": 128
+  },
   "windmill": {
     "height": 20,
     "pixelRatio": 1,

--- a/demo/sprites/river@2x.json
+++ b/demo/sprites/river@2x.json
@@ -265,6 +265,13 @@
     "x": 208,
     "y": 256
   },
+  "hazard": {
+    "height": 44,
+    "pixelRatio": 2,
+    "width": 44,
+    "x": 208,
+    "y": 256
+  },
   "windmill": {
     "height": 40,
     "pixelRatio": 2,


### PR DESCRIPTION
1. Upių žemėlapiuose buvo praleistos/nerodomos pavojingos vietos (_whitewater=hazard_):
![paveikslas](https://user-images.githubusercontent.com/969513/107535918-dd47c980-6bc9-11eb-984c-e81f3fea8c9c.png)

2. Generalizuojant upių orientyrus buvo praleistas variantas egress;bridge
![paveikslas](https://user-images.githubusercontent.com/969513/107536149-226bfb80-6bca-11eb-9941-5ceeffc0cc8c.png)
