### PR TITLE
Pakilimo takui tinka ir area:aeroway

### DIFF
--- a/data/landuse/z12.pgsql
+++ b/data/landuse/z12.pgsql
@@ -24,6 +24,8 @@ SELECT
         THEN 'scrub'
       WHEN aeroway is not null
         THEN aeroway
+      WHEN "area:aeroway" is not null
+        THEN "area:aeroway"
     END
   ) AS kind
 FROM
@@ -33,7 +35,8 @@ WHERE
   (
     landuse IN ('residential', 'commercial', 'industrial', 'meadow', 'farmland', 'allotments', 'cemetery', 'garages', 'orchard', 'farmyard', 'retail', 'railway', 'quarry') OR
    "natural" in ('wetland', 'beach', 'sand', 'scrub', 'heath') OR
-   aeroway = 'runway'
+   aeroway = 'runway' OR
+   "area:aeroway" = 'runway'
   ) AND
   way_area >= 12800
 

--- a/data/landuse/z13.pgsql
+++ b/data/landuse/z13.pgsql
@@ -24,6 +24,8 @@ SELECT
         THEN 'scrub'
       WHEN aeroway is not null
         THEN aeroway
+      WHEN "area:aeroway" is not null
+        THEN "area:aeroway"
     END
   ) AS kind
 FROM
@@ -34,6 +36,7 @@ WHERE
     landuse in ('residential', 'commercial', 'industrial', 'meadow', 'farmland', 'allotments', 'cemetery', 'garages', 'orchard', 'farmyard', 'retail', 'railway', 'quarry')
     OR "natural" in ('wetland', 'sand', 'beach', 'scrub', 'heath')
     OR aeroway in ('runway')
+    OR "area:aeroway" = 'runway'
   ) AND
   way_area >= 3200
 

--- a/data/landuse/z14.pgsql
+++ b/data/landuse/z14.pgsql
@@ -24,6 +24,8 @@ SELECT
         THEN 'scrub'
       WHEN aeroway is not null
         THEN aeroway
+      WHEN "area:aeroway" is not null
+        THEN "area:aeroway"
       WHEN amenity = 'grave_yard'
         THEN 'cemetery'
     END
@@ -36,6 +38,7 @@ WHERE
     landuse in ('residential', 'commercial', 'industrial', 'meadow', 'farmland', 'allotments', 'cemetery', 'garages', 'orchard', 'farmyard', 'retail', 'railway', 'quarry')
     OR "natural" in ('wetland', 'sand', 'beach', 'scrub', 'heath')
     OR aeroway in ('apron', 'runway')
+    OR "area:aeroway" = 'runway'
     OR amenity = 'grave_yard'
   ) AND
   way_area >= 800

--- a/data/landuse/z15.pgsql
+++ b/data/landuse/z15.pgsql
@@ -24,6 +24,8 @@ SELECT
         THEN 'scrub'
       WHEN aeroway is not null
         THEN aeroway
+      WHEN "area:aeroway" is not null
+        THEN "area:aeroway"
       WHEN amenity = 'grave_yard'
         THEN 'cemetery'
     END
@@ -36,6 +38,7 @@ WHERE
     landuse in ('forest', 'residential', 'commercial', 'industrial', 'meadow', 'farmland', 'allotments', 'cemetery', 'garages', 'orchard', 'farmyard', 'retail', 'railway', 'quarry')
     OR "natural" in ('wetland', 'sand', 'beach', 'scrub', 'heath')
     OR aeroway in ('apron', 'runway')
+    OR "area:aeroway" = 'runway'
     OR amenity = 'grave_yard'
   ) AND
   way_area >= 200

--- a/data/landuse/z16.pgsql
+++ b/data/landuse/z16.pgsql
@@ -26,6 +26,8 @@ SELECT
         THEN leisure
       WHEN aeroway is not null
         THEN aeroway
+      WHEN "area:aeroway" is not null
+        THEN "area:aeroway"
       WHEN amenity = 'grave_yard'
         THEN 'cemetery'
     END
@@ -39,5 +41,6 @@ WHERE
     OR "natural" in ('wetland', 'sand', 'beach', 'scrub', 'heath')
     OR leisure = 'park'
     OR aeroway in ('apron', 'runway')
+    OR "area:aeroway" = 'runway'
     OR amenity = 'grave_yard'
   )

--- a/db/osm2pgsql.style
+++ b/db/osm2pgsql.style
@@ -85,6 +85,7 @@ node,way   addr:unit           text  linear
 node,way   admin_level  text         linear
 node,way   aerialway    text         linear
 node,way   aeroway      text         polygon
+way        area:aeroway text         polygon
 node,way   amenity      text         polygon
 node,way   area         text         # hard coded support for area=1/yes => polygon is in osm2pgsql
 node,way   barrier      text         linear


### PR DESCRIPTION
OSM wikyje _aeroway=runway_ pažymėtas kaip nebetinkamas, jis keičiamas į _area:aeroway_. Ta proga pridedamas _area:aeroway_ lygiagretus palaikymas. Po kažkiek laiko bus galima išimti _aeroway=runway_ palaikymą.

Vektorinių kaladėlių turinys nesikeičia, taigi stiliams tai įtakos neturės.

![paveikslas](https://user-images.githubusercontent.com/969513/109825348-69d22e80-7c42-11eb-875f-43b9b13402ab.png)
