### PR TITLE
Vandens telkinių etikečių ID ir senų objektų valymas

### DIFF
--- a/db/func/stc_process_centerlines.sql
+++ b/db/func/stc_process_centerlines.sql
@@ -121,14 +121,14 @@ begin
                   while tl > 4 loop
                     raise notice 'splitting at % (length %)', 2.0 / tl, st_length(g);
                     g = st_split(g, st_buffer(st_LineInterpolatePoint(g, 2.0 / tl), 10));
-                    insert into car_centerline (id, osm_id, name, zoom, size, spacing, way) values (1, c.osm_id, c.name, z, s, prop, st_geometryn(g, 1));
+                    insert into car_centerline (osm_id, name, zoom, size, spacing, way) values (c.osm_id, c.name, z, s, prop, st_geometryn(g, 1));
                     -- note: 2nd geometry is a buffer zone between two parts
                     g = st_geometryn(g, 3);
                     tl = tl - 2;
                   end loop;
-                  insert into car_centerline (id, osm_id, name, zoom, size, spacing, way) values (1, c.osm_id, c.name, z, s, prop, g);
+                  insert into car_centerline (osm_id, name, zoom, size, spacing, way) values (c.osm_id, c.name, z, s, prop, g);
                 else
-                  insert into car_centerline (id, osm_id, name, zoom, size, spacing, way) values (1, c.osm_id, c.name, z, s, prop, g);
+                  insert into car_centerline (osm_id, name, zoom, size, spacing, way) values (c.osm_id, c.name, z, s, prop, g);
                 end if;
               else
                 g = null;

--- a/db/tables/table_car_centerline.sql
+++ b/db/tables/table_car_centerline.sql
@@ -1,6 +1,6 @@
 drop table if exists car_centerline;
 create table car_centerline (
-id bigint,
+id serial,
 osm_id bigint,
 name text,
 zoom integer,

--- a/db/update_water_labels.sql
+++ b/db/update_water_labels.sql
@@ -2,6 +2,8 @@ delete from car_requests where osm_id not in (select osm_id
                                                from planet_osm_polygon
                                               where name is not null
                                                 and ("natural" in ('water', 'bay') or landuse = 'reservoir'));
+delete from car_centerline where osm_id not in (select osm_id from car_requests);
+delete from car_labels where osm_id not in (select osm_id from car_requests);
 insert into car_requests (id, osm_id, type, dirty, last_update)
   select nextval('car_request_seq')
         ,osm_id


### PR DESCRIPTION
1. Kuriant vandens telkinių centro linijas užrašams, ID priskirti iš sekos (iki šiol visi turėjo ID=1)
2. Išvalyti centro linijas objektams, kurie nebėra vandens telkiniai.